### PR TITLE
support index ascenion

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -1,0 +1,68 @@
+package arcticdb
+
+import (
+	"testing"
+
+	"github.com/google/btree"
+	"github.com/stretchr/testify/require"
+)
+
+type FakeGranule struct {
+	islessThan bool // indicates this granule is being used during an Ascend action, and we need to peform a slightly different compare
+	min, max   int  // min max represent the min and max of a Granule
+}
+
+func (f *FakeGranule) Less(than btree.Item) bool {
+	thanf := than.(*FakeGranule)
+
+	if f.islessThan || thanf.islessThan {
+		return f.min <= thanf.min
+	}
+
+	return f.max < thanf.min
+}
+
+// This test validates the assumption the table maekes during iteration, that if we have each btree item having
+// a range of values, that we can successfully use the btree index to filter out nodes we don't want to visit
+func Test_Index_Search(t *testing.T) {
+	index := btree.New(2)
+
+	n := 10
+	for i := 0; i < 1000; i += n {
+		index.ReplaceOrInsert(&FakeGranule{
+			min: i + 1,
+			max: i + n,
+		})
+	}
+
+	searchMin := 50
+	searchMax := 96
+	greaterOrEqual := &FakeGranule{
+		min: searchMin,
+		max: searchMin,
+	}
+	lessThan := &FakeGranule{
+		islessThan: true,
+		min:        searchMax,
+		max:        searchMax,
+	}
+
+	min := -1
+	max := -1
+	index.AscendRange(greaterOrEqual, lessThan, func(item btree.Item) bool {
+		granule := item.(*FakeGranule)
+
+		if min == -1 || granule.min < min {
+			min = granule.min
+		}
+
+		if max == -1 || granule.max > max {
+			max = granule.max
+		}
+
+		return true
+	})
+
+	require.True(t, min <= searchMin)
+	require.True(t, max >= searchMax)
+}

--- a/query/engine.go
+++ b/query/engine.go
@@ -29,10 +29,10 @@ type QueryBuilder struct {
 	planBuilder logicalplan.Builder
 }
 
-func (e *Engine) ScanTable(name string) QueryBuilder {
+func (e *Engine) ScanTable(name string, options ...logicalplan.IterateOption) QueryBuilder {
 	return QueryBuilder{
 		pool:        e.pool,
-		planBuilder: (&logicalplan.Builder{}).Scan(e.tableProvider, name),
+		planBuilder: (&logicalplan.Builder{}).Scan(e.tableProvider, name, options...),
 	}
 }
 

--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -11,15 +11,13 @@ type Builder struct {
 	plan *LogicalPlan
 }
 
-func (b Builder) Scan(
-	provider TableProvider,
-	tableName string,
-) Builder {
+func (b Builder) Scan(provider TableProvider, tableName string, options ...IterateOption) Builder {
 	return Builder{
 		plan: &LogicalPlan{
 			TableScan: &TableScan{
-				TableProvider: provider,
-				TableName:     tableName,
+				TableProvider:  provider,
+				TableName:      tableName,
+				IterateOptions: options,
 			},
 		},
 	}

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/memory"
+	"github.com/polarsignals/arcticdb/dynparquet"
 )
 
 // LogicalPlan is a logical representation of a query. Each LogicalPlan is a
@@ -71,6 +72,39 @@ func (plan *LogicalPlan) Accept(visitor PlanVisitor) bool {
 	return visitor.PostVisit(plan)
 }
 
+type IterateOption interface {
+	Apply(*IterateOptions)
+}
+
+type IterateOptions struct {
+	GreaterOrEqual *dynparquet.DynamicRow
+	LessThan       *dynparquet.DynamicRow
+}
+
+type iterateOption struct {
+	f func(*IterateOptions)
+}
+
+func (i *iterateOption) Apply(options *IterateOptions) {
+	i.f(options)
+}
+
+func LessThan(row *dynparquet.DynamicRow) IterateOption {
+	return &iterateOption{
+		f: func(o *IterateOptions) {
+			o.LessThan = row
+		},
+	}
+}
+
+func GreaterOrEqual(row *dynparquet.DynamicRow) IterateOption {
+	return &iterateOption{
+		f: func(o *IterateOptions) {
+			o.GreaterOrEqual = row
+		},
+	}
+}
+
 type TableReader interface {
 	Iterator(
 		pool memory.Allocator,
@@ -78,6 +112,7 @@ type TableReader interface {
 		filter Expr,
 		distinctColumns []ColumnMatcher,
 		callback func(r arrow.Record) error,
+		opts ...IterateOption,
 	) error
 }
 
@@ -99,6 +134,9 @@ type TableScan struct {
 
 	// Distinct describes the columns that are to be distinct.
 	Distinct []ColumnMatcher
+
+	// IterateOptions are options around iteration
+	IterateOptions []IterateOption
 }
 
 func (scan *TableScan) String() string {

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -73,6 +73,7 @@ func (s *TableScan) Execute(pool memory.Allocator) error {
 		s.options.Filter,
 		s.options.Distinct,
 		s.next.Callback,
+		s.options.IterateOptions...,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds iteration options to the ScanTable builder. This allows queriers to submit pivot rows at query time to only visit a subset of nodes in the index.