### PR TITLE
query/physicalplan: Fix aggregations of nil values

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -93,3 +93,78 @@ func TestAggregate(t *testing.T) {
 	}
 	require.Equal(t, []int64{6}, cols[len(cols)-1].(*array.Int64).Int64Values())
 }
+
+func TestAggregateNils(t *testing.T) {
+	config := NewTableConfig(
+		dynparquet.NewSampleSchema(),
+		8192,
+		512*1024*1024,
+	)
+
+	c := New(nil)
+	db := c.DB("test")
+	table := db.Table("test", config, newTestLogger(t))
+
+	samples := dynparquet.Samples{{
+		Labels: []dynparquet.Label{
+			{Name: "label1", Value: "value1"},
+		},
+		Stacktrace: []uuid.UUID{
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+		},
+		Timestamp: 1,
+		Value:     1,
+	}, {
+		Labels: []dynparquet.Label{
+			{Name: "label2", Value: "value2"},
+		},
+		Stacktrace: []uuid.UUID{
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+		},
+		Timestamp: 2,
+		Value:     2,
+	}, {
+		Labels: []dynparquet.Label{
+			{Name: "label2", Value: "value2"},
+		},
+		Stacktrace: []uuid.UUID{
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+		},
+		Timestamp: 3,
+		Value:     3,
+	}}
+
+	buf, err := samples.ToBuffer(table.Schema())
+	require.NoError(t, err)
+
+	err = table.Insert(buf)
+	require.NoError(t, err)
+
+	engine := query.NewEngine(
+		memory.NewGoAllocator(),
+		db.TableProvider(),
+	)
+
+	var res arrow.Record
+	err = engine.ScanTable("test").
+		Aggregate(
+			logicalplan.Sum(logicalplan.Col("value")).Alias("value_sum"),
+			logicalplan.Col("labels.label2"),
+		).Execute(func(r arrow.Record) error {
+		r.Retain()
+		res = r
+		return nil
+	})
+	require.NoError(t, err)
+	defer res.Release()
+
+	cols := res.Columns()
+	require.Equal(t, 2, len(cols))
+	for i, col := range cols {
+		require.Equal(t, 2, col.Len(), "unexpected number of values in column %s", res.Schema().Field(i).Name)
+	}
+	require.Equal(t, []int64{1, 5}, cols[len(cols)-1].(*array.Int64).Int64Values())
+}

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -155,20 +155,20 @@ func hashArray(arr arrow.Array) []uint64 {
 }
 
 func hashBinaryArray(arr *array.Binary) []uint64 {
-	res := make([]uint64, 0, arr.Len())
+	res := make([]uint64, arr.Len())
 	for i := 0; i < arr.Len(); i++ {
 		if !arr.IsNull(i) {
-			res = append(res, metro.Hash64(arr.Value(i), 0))
+			res[i] = metro.Hash64(arr.Value(i), 0)
 		}
 	}
 	return res
 }
 
 func hashInt64Array(arr *array.Int64) []uint64 {
-	res := make([]uint64, 0, arr.Len())
+	res := make([]uint64, arr.Len())
 	for i := 0; i < arr.Len(); i++ {
 		if !arr.IsNull(i) {
-			res = append(res, uint64(arr.Value(i)))
+			res[i] = uint64(arr.Value(i))
 		}
 	}
 	return res


### PR DESCRIPTION
I believe this fixes the panic reported in https://github.com/polarsignals/arcticdb/issues/26