### PR TITLE
Adjust transaction maintenance interval

### DIFF
--- a/tx_list.go
+++ b/tx_list.go
@@ -66,7 +66,7 @@ func (l *TxPool) Iterate(iterate func(tx uint64) bool) {
 // this function does not return.
 func (l *TxPool) cleaner(watermark *atomic.Uint64) {
 	for {
-		ticker := time.NewTicker(time.Millisecond)
+		ticker := time.NewTicker(time.Millisecond * 10)
 		defer ticker.Stop()
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
Ran current `main` of this with Parca for a while and 99.99% of CPU time of 6 cores on my machine was spent in this timer. This PR relaxes the maintenance interval a bit, but I think we can actually get away without any maintenance goroutine and have transactions advance this themselves when they are done (might create a follow up PR for that).