### PR TITLE
go.mod: Update apache/arrow to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/RoaringBitmap/roaring v0.9.4
-	github.com/apache/arrow/go/v8 v8.0.0-20220330100019-c515a6924f60
+	github.com/apache/arrow/go/v8 v8.0.0-20220414050214-b61fb727fcc9
 	github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140
 	github.com/go-kit/log v0.2.0
 	github.com/google/btree v1.0.1
@@ -40,5 +40,3 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
-
-replace github.com/apache/arrow/go/v8 => github.com/brancz/arrow/go/v8 v8.0.0-20220331075317-4a90e3994fc9

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/apache/arrow/go/v8 v8.0.0-20220414050214-b61fb727fcc9 h1:oW/c7OOBahkTDF6c/3V0HTmzSA3quq8deUstigTcrpY=
+github.com/apache/arrow/go/v8 v8.0.0-20220414050214-b61fb727fcc9/go.mod h1:UUe+gJaMnuFD6icfGSJxUjG/tX/POUbPS/wE+EFyncM=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.15.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=


### PR DESCRIPTION
Now that https://github.com/apache/arrow/pull/12764 is merged, we can use the upstream again.