### PR TITLE
Support AscendRange options

### DIFF
--- a/dynparquet/reader.go
+++ b/dynparquet/reader.go
@@ -30,9 +30,14 @@ func ReaderFromBytes(buf []byte) (*SerializedBuffer, error) {
 }
 
 func NewSerializedBuffer(f *parquet.File) (*SerializedBuffer, error) {
+	b := &SerializedBuffer{
+		Reader: parquet.NewReader(f),
+		f:      f,
+	}
+
 	dynColString, found := f.Lookup(DynamicColumnsKey)
 	if !found {
-		return nil, ErrNoDynamicColumns
+		return b, nil
 	}
 
 	dynCols, err := deserializeDynamicColumns(dynColString)
@@ -40,11 +45,8 @@ func NewSerializedBuffer(f *parquet.File) (*SerializedBuffer, error) {
 		return nil, fmt.Errorf("deserialize dynamic columns metadata %q: %w", dynColString, err)
 	}
 
-	return &SerializedBuffer{
-		Reader:  parquet.NewReader(f),
-		f:       f,
-		dynCols: dynCols,
-	}, nil
+	b.dynCols = dynCols
+	return b, nil
 }
 
 func (b *SerializedBuffer) ParquetFile() *parquet.File {

--- a/dynparquet/row.go
+++ b/dynparquet/row.go
@@ -13,9 +13,8 @@ type DynamicRow struct {
 }
 
 // Intersection returns the intersection of two schemas
-// This is useful when comparing two rows of different schemas to only compare the columns that intersect
+// This is useful when comparing two rows of different schemas to only compare the columns that intersect.
 func Intersection(a, b *parquet.Schema) *parquet.Schema {
-
 	aChildren := a.ChildNames()
 	bChildren := b.ChildNames()
 	aChildMap := map[string]bool{}

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -373,13 +373,20 @@ func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string) (*pa
 		bloomFilterColumns = append(bloomFilterColumns, parquet.SplitBlockFilter(col.Path()...))
 	}
 
-	return parquet.NewWriter(w,
+	options := []parquet.WriterOption{
 		ps,
 		parquet.BloomFilters(bloomFilterColumns...),
-		parquet.KeyValueMetadata(
+	}
+
+	if len(dynamicColumns) != 0 {
+		options = append(options, parquet.KeyValueMetadata(
 			DynamicColumnsKey,
 			serializeDynamicColumns(dynamicColumns),
-		),
+		))
+	}
+
+	return parquet.NewWriter(w,
+		options...,
 	), nil
 }
 

--- a/query/engine.go
+++ b/query/engine.go
@@ -37,10 +37,10 @@ type LocalQueryBuilder struct {
 	planBuilder logicalplan.Builder
 }
 
-func (e *LocalEngine) ScanTable(name string) Builder {
+func (e *LocalEngine) ScanTable(name string, options ...logicalplan.IterateOption) Builder {
 	return LocalQueryBuilder{
 		pool:        e.pool,
-		planBuilder: (&logicalplan.Builder{}).Scan(e.tableProvider, name),
+		planBuilder: (&logicalplan.Builder{}).Scan(e.tableProvider, name, options...),
 	}
 }
 

--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -12,15 +12,13 @@ type Builder struct {
 	plan *LogicalPlan
 }
 
-func (b Builder) Scan(
-	provider TableProvider,
-	tableName string,
-) Builder {
+func (b Builder) Scan(provider TableProvider, tableName string, options ...IterateOption) Builder {
 	return Builder{
 		plan: &LogicalPlan{
 			TableScan: &TableScan{
-				TableProvider: provider,
-				TableName:     tableName,
+				TableProvider:  provider,
+				TableName:      tableName,
+				IterateOptions: options,
 			},
 		},
 	}

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/memory"
+
 	"github.com/polarsignals/arcticdb/dynparquet"
 )
 

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -74,6 +74,7 @@ func (s *TableScan) Execute(pool memory.Allocator) error {
 		s.options.Filter,
 		s.options.Distinct,
 		s.next.Callback,
+		s.options.IterateOptions...,
 	)
 	if err != nil {
 		return err

--- a/table_test.go
+++ b/table_test.go
@@ -942,7 +942,7 @@ func Test_Table_AscendRange(t *testing.T) {
 }
 
 // Test_Table_AscendRange_NoIntersection performs an ascned range with a search schema that has no consecutive overlap with the soreting columns.
-// What this means is that we can't make a valid comparison, and have to return all objects in the tree
+// What this means is that we can't make a valid comparison, and have to return all objects in the tree.
 func Test_Table_AscendRange_NoIntersection(t *testing.T) {
 	table := basicTable(t, 4)
 
@@ -1024,6 +1024,7 @@ func Test_Table_AscendRange_NoIntersection(t *testing.T) {
 		logicalplan.LessThan(bufToRow(t, lessBuf, pivotSchema)),
 		logicalplan.GreaterOrEqual(bufToRow(t, greaterOrEqualBuf, pivotSchema)),
 	)
+	require.NoError(t, err)
 
 	var row2 int64
 	err = table.Iterator(memory.NewGoAllocator(), nil, nil, nil, func(ar arrow.Record) error {


### PR DESCRIPTION
Usage of AscendRange during iteration if given pivot options.

Since we have a multi-column primary key, it performs an intersection of the given pivot row schema and the table schema. Using this intersection it performs a comparison using the overlapping sorted columns. If a sorted column doesn't exist in the pivot schema, it's considered equal since it isn't known if that granule is less than the pivot. This can be seen in use with the unit tests where it pivots around a sample type and only ends up iterating over a subset of the granules.

In Parca we'll want to rearrange our sorted columns to be able to leverage this better, with the timestamps being the second sorted column.