### PR TITLE
fix error writing table when schema has no dyanmic columns

### DIFF
--- a/dynparquet/dynamiccolumns.go
+++ b/dynparquet/dynamiccolumns.go
@@ -29,6 +29,11 @@ func serializeDynamicColumns(dynamicColumns map[string][]string) string {
 func deserializeDynamicColumns(dynColString string) (map[string][]string, error) {
 	dynCols := map[string][]string{}
 
+	// handle case where the schema has no dynamic columnns
+	if len(dynColString) == 0 {
+		return dynCols, nil
+	}
+
 	for _, dynString := range strings.Split(dynColString, ";") {
 		split := strings.Split(dynString, ":")
 		if len(split) != 2 {

--- a/dynparquet/dynamiccolumns_test.go
+++ b/dynparquet/dynamiccolumns_test.go
@@ -43,3 +43,12 @@ func TestDynamicColumnsDeserialization(t *testing.T) {
 	}
 	require.Equal(t, expected, output)
 }
+
+func TestDynamicColumnsDeserialization_NoDynamicColumns(t *testing.T) {
+	input := ""
+	output, err := deserializeDynamicColumns(input)
+	require.NoError(t, err)
+
+	expected := map[string][]string{}
+	require.Equal(t, expected, output)
+}


### PR DESCRIPTION
Inserting into the table will return an error if the table schema has no dynamic columns. 

Here is an example that replicates the issue:
```golang
package main

import (
	"github.com/go-kit/log"
	"github.com/go-kit/log/level"
	"github.com/polarsignals/arcticdb"
	"github.com/polarsignals/arcticdb/dynparquet"
	"github.com/segmentio/parquet-go"
	"os"
)

func main() {
	var err error
	columnstore := arcticdb.New(nil)
	db := columnstore.DB("test_db")

	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
	logger = level.NewFilter(logger, level.AllowDebug())

	schema := dynparquet.NewSchema("test_schema",
		[]dynparquet.ColumnDefinition{
			{
				Name:          "Column1",
				StorageLayout: parquet.Encoded(parquet.String(), &parquet.RLEDictionary),
				Dynamic:       false,
			},
		},
		[]dynparquet.SortingColumn{
			dynparquet.Ascending("Column1"),
		})
	tableConfig := arcticdb.NewTableConfig(schema, 256, 512*1024*1024)

	table, err := db.Table("test_table", tableConfig, logger)
	if err != nil {
		panic(err)
	}

	buffer, err := schema.NewBuffer(map[string][]string{})
	if err != nil {
		panic(err)
	}

	row := make([]parquet.Value, 0)
	row = append(row, parquet.ValueOf("hello").Level(0, 0, 0))
	err = buffer.WriteRow(row)
	if err != nil {
		panic(err)
	}

	err = table.Insert(buffer)
	if err != nil {
		panic(err)
	}
}

```

```
panic: failed to split rows by granule: failed to create dynparquet reader: deserialize dynamic columns metadata "": malformed dynamic columns string

goroutine 1 [running]:
main.main()
        /Users/albert.lockett2/Development/arcticdb/albert/main.go:52 +0x6e5
```
