### PR TITLE
Return result if left expr eval to false in AndExpr

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -118,6 +118,9 @@ func (a *AndExpr) Eval(rg dynparquet.DynamicRowGroup) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if !left {
+		return false, nil
+	}
 
 	right, err := a.Right.Eval(rg)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

If the left expr evals to false then seems it is always false for `AndExpr`.
I am still new to the codebase so not sure if there is any edge case here...