### PR TITLE
replace[dynparquet/scheme.go]:replace boolean map with empty structs …

### DIFF
--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -507,12 +507,12 @@ func mergeDynamicColumns(dyn [][]string) []string {
 // deduplicated slice of strings.
 func mergeStrings(str [][]string) []string {
 	result := []string{}
-	seen := map[string]bool{}
+	seen := map[string]struct{}{}
 	for _, s := range str {
 		for _, n := range s {
-			if !seen[n] {
+			if _, ok := seen[n]; !ok {
 				result = append(result, n)
-				seen[n] = true
+				seen[n] = struct{}{}
 			}
 		}
 	}


### PR DESCRIPTION
https://dave.cheney.net/2014/03/25/the-empty-struct
The previous approach was generating allocating boolean values for creating string sets, a new approach is allocation free for map values.