### PR TITLE
Filter whole granules during query

### DIFF
--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -9,6 +9,11 @@ import (
 	"github.com/segmentio/parquet-go"
 )
 
+const (
+	// The size of the column indicies in parquet files
+	ColumnIndexSize = 16
+)
+
 // ColumnDefinition describes a column in a dynamic parquet schema.
 type ColumnDefinition struct {
 	Name          string
@@ -415,7 +420,7 @@ func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string) (*pa
 
 	return parquet.NewWriter(w,
 		ps,
-		parquet.ColumnIndexSizeLimit(32),
+		parquet.ColumnIndexSizeLimit(ColumnIndexSize),
 		parquet.BloomFilters(bloomFilterColumns...),
 		parquet.KeyValueMetadata(
 			DynamicColumnsKey,

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	// The size of the column indicies in parquet files
+	// The size of the column indicies in parquet files.
 	ColumnIndexSize = 16
 )
 

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -415,6 +415,7 @@ func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string) (*pa
 
 	return parquet.NewWriter(w,
 		ps,
+		parquet.ColumnIndexSizeLimit(32),
 		parquet.BloomFilters(bloomFilterColumns...),
 		parquet.KeyValueMetadata(
 			DynamicColumnsKey,

--- a/granule.go
+++ b/granule.go
@@ -258,7 +258,7 @@ func (g *Granule) minmaxes(p *Part) bool {
 				page := p.Values()
 				values := make([]parquet.Value, p.NumValues())
 				_, err = page.ReadValues(values)
-				if err != nil {
+				if err != nil && err != io.EOF {
 					return false
 				}
 

--- a/granule.go
+++ b/granule.go
@@ -72,6 +72,9 @@ func NewGranule(granulesCreated prometheus.Counter, tableConfig *TableConfig, fi
 			return nil, err
 		}
 		g.metadata.least.Store(unsafe.Pointer(row))
+
+		// Set the minmaxes on the new granule
+		g.minmaxes(firstPart)
 	}
 
 	granulesCreated.Inc()

--- a/granule.go
+++ b/granule.go
@@ -267,37 +267,33 @@ func (g *Granule) minmaxes(p *Part) error {
 					break
 				}
 
-				switch values[0].Kind() {
-				default:
-
-					// Check for min
-					min := findMin(values)
-					g.metadata.minlock.RLock()
-					val := g.metadata.min[rowGroup.Schema().Fields()[columnChunk.Column()].Name()]
-					g.metadata.minlock.RUnlock()
-					if val == nil || Compare(*val, *min) == 1 {
-						if !min.IsNull() {
-							g.metadata.minlock.Lock() // Check again after acquiring the write lock
-							if val := g.metadata.min[rowGroup.Schema().Fields()[columnChunk.Column()].Name()]; val == nil || Compare(*val, *min) == 1 {
-								g.metadata.min[rowGroup.Schema().Fields()[columnChunk.Column()].Name()] = min
-							}
-							g.metadata.minlock.Unlock()
+				// Check for min
+				min := findMin(values)
+				g.metadata.minlock.RLock()
+				val := g.metadata.min[rowGroup.Schema().Fields()[columnChunk.Column()].Name()]
+				g.metadata.minlock.RUnlock()
+				if val == nil || Compare(*val, *min) == 1 {
+					if !min.IsNull() {
+						g.metadata.minlock.Lock() // Check again after acquiring the write lock
+						if val := g.metadata.min[rowGroup.Schema().Fields()[columnChunk.Column()].Name()]; val == nil || Compare(*val, *min) == 1 {
+							g.metadata.min[rowGroup.Schema().Fields()[columnChunk.Column()].Name()] = min
 						}
+						g.metadata.minlock.Unlock()
 					}
+				}
 
-					// Check for max
-					max := findMax(values)
-					g.metadata.maxlock.RLock()
-					val = g.metadata.max[rowGroup.Schema().Fields()[columnChunk.Column()].Name()]
-					g.metadata.maxlock.RUnlock()
-					if val == nil || Compare(*val, *max) == -1 {
-						if !max.IsNull() {
-							g.metadata.maxlock.Lock() // Check again after acquiring the write lock
-							if val := g.metadata.max[rowGroup.Schema().Fields()[columnChunk.Column()].Name()]; val == nil || Compare(*val, *max) == -1 {
-								g.metadata.max[rowGroup.Schema().Fields()[columnChunk.Column()].Name()] = max
-							}
-							g.metadata.maxlock.Unlock()
+				// Check for max
+				max := findMax(values)
+				g.metadata.maxlock.RLock()
+				val = g.metadata.max[rowGroup.Schema().Fields()[columnChunk.Column()].Name()]
+				g.metadata.maxlock.RUnlock()
+				if val == nil || Compare(*val, *max) == -1 {
+					if !max.IsNull() {
+						g.metadata.maxlock.Lock() // Check again after acquiring the write lock
+						if val := g.metadata.max[rowGroup.Schema().Fields()[columnChunk.Column()].Name()]; val == nil || Compare(*val, *max) == -1 {
+							g.metadata.max[rowGroup.Schema().Fields()[columnChunk.Column()].Name()] = max
 						}
+						g.metadata.maxlock.Unlock()
 					}
 				}
 			}

--- a/granule.go
+++ b/granule.go
@@ -102,8 +102,6 @@ func (g *Granule) AddPart(p *Part) (uint64, error) {
 
 	// Set the minmaxes for the granule
 	g.minmaxes(p)
-	fmt.Println("min: ", g.metadata.min) // TODO(THOR): remove me
-	fmt.Println("max: ", g.metadata.max) // TODO(THOR): remove me
 
 	// If the prepend returned that we're adding to the compacted list; then we need to propogate the Part to the new granules
 	if node.sentinel == Compacted {

--- a/granule.go
+++ b/granule.go
@@ -74,7 +74,9 @@ func NewGranule(granulesCreated prometheus.Counter, tableConfig *TableConfig, fi
 		g.metadata.least.Store(unsafe.Pointer(row))
 
 		// Set the minmaxes on the new granule
-		g.minmaxes(firstPart)
+		if err := g.minmaxes(firstPart); err != nil {
+			return nil, err
+		}
 	}
 
 	granulesCreated.Inc()

--- a/granule.go
+++ b/granule.go
@@ -27,7 +27,7 @@ type Granule struct {
 	newGranules []*Granule
 }
 
-// GranuleMetadata is the metadata for a granule
+// GranuleMetadata is the metadata for a granule.
 type GranuleMetadata struct {
 	// least is the row that exists within the Granule that is the least.
 	// This is used for quick insertion into the btree, without requiring an iterator
@@ -234,11 +234,8 @@ func (g *Granule) Least() *dynparquet.DynamicRow {
 	return (*dynparquet.DynamicRow)(g.metadata.least.Load())
 }
 
-var err error
-
-// minmaxes finds the mins and maxes of every column in a part
+// minmaxes finds the mins and maxes of every column in a part.
 func (g *Granule) minmaxes(p *Part) bool {
-
 	f := p.Buf.ParquetFile()
 	numRowGroups := f.NumRowGroups()
 	for i := 0; i < numRowGroups; i++ {
@@ -260,7 +257,10 @@ func (g *Granule) minmaxes(p *Part) bool {
 
 				page := p.Values()
 				values := make([]parquet.Value, p.NumValues())
-				page.ReadValues(values)
+				_, err = page.ReadValues(values)
+				if err != nil {
+					return false
+				}
 
 				switch values[0].Kind() {
 				default:

--- a/table.go
+++ b/table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/array"
 	"github.com/apache/arrow/go/v8/arrow/memory"
+	"github.com/apache/arrow/go/v8/arrow/scalar"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/btree"
@@ -235,7 +236,7 @@ func (t *Table) Iterator(
 	}
 
 	rowGroups := []dynparquet.DynamicRowGroup{}
-	err = t.ActiveBlock().RowGroupIterator(filter, func(rg dynparquet.DynamicRowGroup) bool {
+	err = t.ActiveBlock().RowGroupIterator(filterExpr, filter, func(rg dynparquet.DynamicRowGroup) bool {
 		rowGroups = append(rowGroups, rg)
 		return true
 	})
@@ -285,7 +286,7 @@ func (t *Table) SchemaIterator(
 	}
 
 	rowGroups := []dynparquet.DynamicRowGroup{}
-	err = t.ActiveBlock().RowGroupIterator(filter, func(rg dynparquet.DynamicRowGroup) bool {
+	err = t.ActiveBlock().RowGroupIterator(nil, filter, func(rg dynparquet.DynamicRowGroup) bool {
 		rowGroups = append(rowGroups, rg)
 		return true
 	})
@@ -551,6 +552,7 @@ func (t *TableBlock) splitGranule(granule *Granule) {
 
 // Iterator iterates in order over all granules in the table. It stops iterating when the iterator function returns false.
 func (t *TableBlock) RowGroupIterator(
+	filterExpr logicalplan.Expr,
 	filter TrueNegativeFilter,
 	iterator func(rg dynparquet.DynamicRowGroup) bool,
 ) error {
@@ -562,6 +564,61 @@ func (t *TableBlock) RowGroupIterator(
 		g := i.(*Granule)
 
 		// TODO check granule metadata against filters
+		if filterExpr != nil {
+			switch expr := filterExpr.(type) {
+			case logicalplan.BinaryExpr:
+				matchers := expr.Left.ColumnsUsed()
+				for column, min := range g.metadata.min {
+					for _, matcher := range matchers {
+						if matcher.Match(column) {
+							switch leftExpr := expr.Left.(type) {
+							case logicalplan.BinaryExpr:
+								switch leftExpr.Op {
+								case logicalplan.GTOp:
+									switch literal := leftExpr.Right.(type) {
+									case logicalplan.LiteralExpr:
+										v := literal.Value.(*scalar.Int64)
+										if g.metadata.max[column].Int64() <= v.Value {
+											return true
+										}
+									}
+								case logicalplan.LTOp:
+									switch literal := leftExpr.Right.(type) {
+									case logicalplan.LiteralExpr:
+										v := literal.Value.(*scalar.Int64)
+										fmt.Println(leftExpr)
+										if min.Int64() >= v.Value {
+											return true
+										}
+									}
+								}
+							}
+							switch rightExpr := expr.Right.(type) {
+							case logicalplan.BinaryExpr:
+								switch rightExpr.Op {
+								case logicalplan.GTOp:
+									switch literal := rightExpr.Right.(type) {
+									case logicalplan.LiteralExpr:
+										v := literal.Value.(*scalar.Int64)
+										if g.metadata.max[column].Int64() <= v.Value {
+											return true
+										}
+									}
+								case logicalplan.LTOp:
+									switch literal := rightExpr.Right.(type) {
+									case logicalplan.LiteralExpr:
+										v := literal.Value.(*scalar.Int64)
+										if min.Int64() >= v.Value {
+											return true
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
 
 		g.PartBuffersForTx(watermark, func(buf *dynparquet.SerializedBuffer) bool {
 			f := buf.ParquetFile()

--- a/table.go
+++ b/table.go
@@ -807,7 +807,7 @@ func (t *TableBlock) abort(commit func(), granule *Granule) {
 	}
 }
 
-// filterGranule returns false if this granule does not contain useful data
+// filterGranule returns false if this granule does not contain useful data.
 func filterGranule(filterExpr logicalplan.Expr, g *Granule) bool {
 	if filterExpr == nil {
 		return true

--- a/table.go
+++ b/table.go
@@ -869,6 +869,13 @@ func filterGranule(filterExpr logicalplan.Expr, g *Granule) bool {
 				case *scalar.String:
 					return string(val.Value.Bytes()) > min.String()
 				}
+			case logicalplan.EqOp:
+				switch val := v.(type) {
+				case *scalar.Int64:
+					return val.Value == min.Int64()
+				case *scalar.String:
+					return string(val.Value.Bytes()) == min.String()
+				}
 			}
 
 		case logicalplan.LiteralExpr:
@@ -879,6 +886,8 @@ func filterGranule(filterExpr logicalplan.Expr, g *Granule) bool {
 					return min.Int64() < v.Value
 				case logicalplan.GTOp:
 					return max.Int64() > v.Value
+				case logicalplan.EqOp:
+					return max.Int64() == v.Value
 				}
 			case *scalar.String:
 				switch expr.Op {
@@ -886,6 +895,8 @@ func filterGranule(filterExpr logicalplan.Expr, g *Granule) bool {
 					return min.String() < string(v.Value.Bytes())
 				case logicalplan.GTOp:
 					return max.String() > string(v.Value.Bytes())
+				case logicalplan.EqOp:
+					return max.String() == string(v.Value.Bytes())
 				}
 			}
 		}

--- a/table_test.go
+++ b/table_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/polarsignals/arcticdb/dynparquet"
+	"github.com/polarsignals/arcticdb/query/logicalplan"
 )
 
 type testOutput struct {
@@ -142,7 +143,12 @@ func TestTable(t *testing.T) {
 	_, err = table.InsertBuffer(buf)
 	require.NoError(t, err)
 
-	err = table.Iterator(memory.NewGoAllocator(), nil, nil, nil, func(ar arrow.Record) error {
+	filterExpr := logicalplan.And(
+		logicalplan.Col("timestamp").GT(logicalplan.Literal(-10)),
+		logicalplan.Col("timestamp").LT(logicalplan.Literal(1)),
+	)
+
+	err = table.Iterator(memory.NewGoAllocator(), nil, filterExpr, nil, func(ar arrow.Record) error {
 		t.Log(ar)
 		defer ar.Release()
 

--- a/table_test.go
+++ b/table_test.go
@@ -158,7 +158,7 @@ func TestTable(t *testing.T) {
 	// One granule with 3 parts
 	require.Equal(t, 1, table.active.Index().Len())
 	require.Equal(t, uint64(3), table.active.Index().Min().(*Granule).parts.total.Load())
-	require.Equal(t, uint64(5), table.active.Index().Min().(*Granule).card.Load())
+	require.Equal(t, uint64(5), table.active.Index().Min().(*Granule).metadata.card.Load())
 	require.Equal(t, parquet.Row{
 		parquet.ValueOf("test").Level(0, 0, 0),
 		parquet.ValueOf("value1").Level(0, 1, 1),
@@ -168,7 +168,7 @@ func TestTable(t *testing.T) {
 		parquet.ValueOf(append(uuid1[:], uuid2[:]...)).Level(0, 0, 5),
 		parquet.ValueOf(1).Level(0, 0, 6),
 		parquet.ValueOf(1).Level(0, 0, 7),
-	}, (*dynparquet.DynamicRow)(table.active.Index().Min().(*Granule).least.Load()).Row)
+	}, (*dynparquet.DynamicRow)(table.active.Index().Min().(*Granule).metadata.least.Load()).Row)
 	require.Equal(t, 1, table.active.Index().Len())
 }
 
@@ -277,8 +277,8 @@ func Test_Table_GranuleSplit(t *testing.T) {
 	})
 
 	require.Equal(t, 2, table.active.Index().Len())
-	require.Equal(t, uint64(2), table.active.Index().Min().(*Granule).card.Load())
-	require.Equal(t, uint64(3), table.active.Index().Max().(*Granule).card.Load())
+	require.Equal(t, uint64(2), table.active.Index().Min().(*Granule).metadata.card.Load())
+	require.Equal(t, uint64(3), table.active.Index().Max().(*Granule).metadata.card.Load())
 }
 
 /*
@@ -360,8 +360,8 @@ func Test_Table_InsertLowest(t *testing.T) {
 	}
 
 	require.Equal(t, 2, table.active.Index().Len())
-	require.Equal(t, uint64(2), table.active.Index().Min().(*Granule).card.Load()) // [13, 12]
-	require.Equal(t, uint64(2), table.active.Index().Max().(*Granule).card.Load()) // [11, 10]
+	require.Equal(t, uint64(2), table.active.Index().Min().(*Granule).metadata.card.Load()) // [13, 12]
+	require.Equal(t, uint64(2), table.active.Index().Max().(*Granule).metadata.card.Load()) // [11, 10]
 
 	samples = dynparquet.Samples{{
 		Labels: []dynparquet.Label{
@@ -385,8 +385,8 @@ func Test_Table_InsertLowest(t *testing.T) {
 	table.Sync()
 
 	require.Equal(t, 2, table.active.Index().Len())
-	require.Equal(t, uint64(3), table.active.Index().Min().(*Granule).card.Load()) // [14, 13, 12]
-	require.Equal(t, uint64(2), table.active.Index().Max().(*Granule).card.Load()) // [11, 10]
+	require.Equal(t, uint64(3), table.active.Index().Min().(*Granule).metadata.card.Load()) // [14, 13, 12]
+	require.Equal(t, uint64(2), table.active.Index().Max().(*Granule).metadata.card.Load()) // [11, 10]
 
 	// Insert a new column that is the lowest column yet; expect it to be added to the minimum column
 	samples = dynparquet.Samples{{
@@ -417,8 +417,8 @@ func Test_Table_InsertLowest(t *testing.T) {
 	})
 
 	require.Equal(t, 2, table.active.Index().Len())
-	require.Equal(t, uint64(3), table.active.Index().Min().(*Granule).card.Load()) // [14,13,12]
-	require.Equal(t, uint64(3), table.active.Index().Max().(*Granule).card.Load()) // [11,10,1]
+	require.Equal(t, uint64(3), table.active.Index().Min().(*Granule).metadata.card.Load()) // [14,13,12]
+	require.Equal(t, uint64(3), table.active.Index().Max().(*Granule).metadata.card.Load()) // [11,10,1]
 }
 
 // This test issues concurrent writes to the database, and expects all of them to be recorded successfully.


### PR DESCRIPTION
Moves column metadata up into the Granule layer. We maintain a list of min/max values for each column stored in a Granule. Then when iterating we can use the filter expr to determine if there's any valid data in the Granule, and skip reading it entirely if there isn't.