### PR TITLE
update segmentio/parquet-go

### DIFF
--- a/binaryscalarexpr.go
+++ b/binaryscalarexpr.go
@@ -20,7 +20,7 @@ func (c *ColumnRef) Column(rg dynparquet.DynamicRowGroup) (parquet.ColumnChunk, 
 	var columnChunk parquet.ColumnChunk
 	// columnChunk can be nil if the column is not present in the row group.
 	if columnIndex != -1 {
-		columnChunk = rg.Column(columnIndex)
+		columnChunk = rg.ColumnChunks()[columnIndex]
 	}
 
 	return columnChunk, columnIndex != -1, nil

--- a/dynparquet/nil_chunk.go
+++ b/dynparquet/nil_chunk.go
@@ -213,7 +213,7 @@ func (p *nilPage) Slice(i, j int64) parquet.BufferedPage {
 // WriteTo is unimplemented, since the page is virtual and does not need to be
 // written in its current usage in this package. If that changes this method
 // needs to be implemented. Implements the parquet.BufferedPage interface.
-func (p *nilPage) WriteTo(encoding.Encoder) error {
+func (p *nilPage) Encode([]byte, encoding.Encoding) ([]byte, error) {
 	panic("not implemented")
 }
 

--- a/dynparquet/reader.go
+++ b/dynparquet/reader.go
@@ -58,16 +58,15 @@ func (b *SerializedBuffer) NumRows() int64 {
 }
 
 func (b *SerializedBuffer) NumRowGroups() int {
-	return b.f.NumRowGroups()
+	return len(b.f.RowGroups())
 }
 
 func (b *SerializedBuffer) DynamicRows() DynamicRows {
-	num := b.NumRowGroups()
-	drg := make([]DynamicRowGroup, num)
-	for i := 0; i < num; i++ {
-		drg[i] = b.DynamicRowGroup(i)
+	rowGroups := b.f.RowGroups()
+	drg := make([]DynamicRowGroup, len(rowGroups))
+	for i, rowGroup := range rowGroups {
+		drg[i] = b.newDynamicRowGroup(rowGroup)
 	}
-
 	return Concat(drg...).DynamicRows()
 }
 
@@ -77,8 +76,12 @@ type serializedRowGroup struct {
 }
 
 func (b *SerializedBuffer) DynamicRowGroup(i int) DynamicRowGroup {
+	return b.newDynamicRowGroup(b.f.RowGroups()[i])
+}
+
+func (b *SerializedBuffer) newDynamicRowGroup(rowGroup parquet.RowGroup) DynamicRowGroup {
 	return &serializedRowGroup{
-		RowGroup: b.f.RowGroup(i),
+		RowGroup: rowGroup,
 		dynCols:  b.dynCols,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/btree v1.0.1
 	github.com/google/uuid v1.3.0
 	github.com/prometheus/client_golang v1.12.1
-	github.com/segmentio/parquet-go v0.0.0-20220511171108-414f4f5a699b
+	github.com/segmentio/parquet-go v0.0.0-20220511210326-4f4d804bcd3a
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/atomic v1.9.0
 )

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/btree v1.0.1
 	github.com/google/uuid v1.3.0
 	github.com/prometheus/client_golang v1.12.1
-	github.com/segmentio/parquet-go v0.0.0-20220421002521-93f8e5ed3407
+	github.com/segmentio/parquet-go v0.0.0-20220511171108-414f4f5a699b
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/atomic v1.9.0
 )
@@ -24,7 +24,7 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/goccy/go-json v0.7.10 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/klauspost/compress v1.15.1 // indirect
+	github.com/klauspost/compress v1.15.2 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
@@ -34,7 +34,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	github.com/segmentio/encoding v0.3.3 // indirect
+	github.com/segmentio/encoding v0.3.5 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 // indirect
 	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
 	golang.org/x/tools v0.1.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -277,8 +277,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.1/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.14.2/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.15.1 h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583BL1A=
-github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.2 h1:3WH+AG7s2+T8o3nrM/8u2rdqUEcQhmga7smjrT41nAw=
+github.com/klauspost/compress v1.15.2/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -401,10 +401,10 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
-github.com/segmentio/encoding v0.3.3 h1:VG1HceOLwHkSDdkxshlu9pD4FftWkScmHc8RDQ+w9uM=
-github.com/segmentio/encoding v0.3.3/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20220421002521-93f8e5ed3407 h1:Pz9rS42lX6XZ+GBsV2SdGyNDalo5beooPXMO7dCe1G0=
-github.com/segmentio/parquet-go v0.0.0-20220421002521-93f8e5ed3407/go.mod h1:HBHoETTgIDcNyTWTVOvCelN6kbFozuTNZPLyRIBjW2E=
+github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
+github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
+github.com/segmentio/parquet-go v0.0.0-20220511171108-414f4f5a699b h1:xX4PMHxdkI+7CI6upQPLTNU9fBf/6RrlsX8+5QtWUwQ=
+github.com/segmentio/parquet-go v0.0.0-20220511171108-414f4f5a699b/go.mod h1:DMN6PChc8JaI7whze9XQn1aCv+8D7nhQKMfL8zXNjX4=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSv
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/segmentio/parquet-go v0.0.0-20220511171108-414f4f5a699b h1:xX4PMHxdkI+7CI6upQPLTNU9fBf/6RrlsX8+5QtWUwQ=
 github.com/segmentio/parquet-go v0.0.0-20220511171108-414f4f5a699b/go.mod h1:DMN6PChc8JaI7whze9XQn1aCv+8D7nhQKMfL8zXNjX4=
+github.com/segmentio/parquet-go v0.0.0-20220511210326-4f4d804bcd3a h1:GJ+IvAkKk++n419fRBbGhCUXENGIsxh89aAZTe3TJVM=
+github.com/segmentio/parquet-go v0.0.0-20220511210326-4f4d804bcd3a/go.mod h1:DMN6PChc8JaI7whze9XQn1aCv+8D7nhQKMfL8zXNjX4=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/granule.go
+++ b/granule.go
@@ -157,9 +157,8 @@ func (g *Granule) split(tx uint64, n int) ([]*Granule, error) {
 	rowsWritten := 0
 
 	f := p.Buf.ParquetFile()
-	rowGroups := f.NumRowGroups()
-	for i := 0; i < rowGroups; i++ {
-		rows := f.RowGroup(i).Rows()
+	for _, rowGroup := range f.RowGroups() {
+		rows := rowGroup.Rows()
 		for {
 			row, err = rows.ReadRow(row[:0])
 			if err == io.EOF {
@@ -244,14 +243,9 @@ func (g *Granule) Least() *dynparquet.DynamicRow {
 // minmaxes finds the mins and maxes of every column in a part.
 func (g *Granule) minmaxes(p *Part) error {
 	f := p.Buf.ParquetFile()
-	numRowGroups := f.NumRowGroups()
-	for i := 0; i < numRowGroups; i++ {
-		rowGroup := f.RowGroup(i)
 
-		numColumns := rowGroup.NumColumns()
-		for j := 0; j < numColumns; j++ {
-			columnChunk := rowGroup.Column(j)
-
+	for _, rowGroup := range f.RowGroups() {
+		for _, columnChunk := range rowGroup.ColumnChunks() {
 			idx := columnChunk.ColumnIndex()
 			minvalues := make([]parquet.Value, 0, idx.NumPages())
 			maxvalues := make([]parquet.Value, 0, idx.NumPages())

--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -118,6 +118,7 @@ func contiguousParquetRowGroupToArrowRecord(
 	distinctColumns []logicalplan.ColumnMatcher,
 ) (arrow.Record, error) {
 	s := rg.Schema()
+	parquetColumns := rg.ColumnChunks()
 	parquetFields := s.Fields()
 
 	if len(distinctColumns) == 1 && filterExpr == nil {
@@ -136,7 +137,7 @@ func contiguousParquetRowGroupToArrowRecord(
 					typ, nullable, array, err := parquetColumnToArrowArray(
 						pool,
 						field,
-						rg.Column(i),
+						parquetColumns[i],
 						true,
 					)
 					if err != nil {
@@ -169,7 +170,7 @@ func contiguousParquetRowGroupToArrowRecord(
 				typ, nullable, array, err := parquetColumnToArrowArray(
 					pool,
 					parquetField,
-					rg.Column(i),
+					parquetColumns[i],
 					false,
 				)
 				if err != nil {

--- a/table.go
+++ b/table.go
@@ -420,7 +420,9 @@ func (t *TableBlock) splitGranule(granule *Granule) {
 			return true
 		}
 
-		for i := 0; i < p.Buf.NumRowGroups(); i++ {
+		// TODO: should there be a method on p.Buf to get the list of dynamic
+		// row groups instead of having to do this conversion?
+		for i, n := 0, p.Buf.NumRowGroups(); i < n; i++ {
 			bufs = append(bufs, p.Buf.DynamicRowGroup(i))
 		}
 
@@ -585,7 +587,7 @@ func (t *TableBlock) RowGroupIterator(
 
 		g.PartBuffersForTx(watermark, func(buf *dynparquet.SerializedBuffer) bool {
 			f := buf.ParquetFile()
-			for i := 0; i < f.NumRowGroups(); i++ {
+			for i := range f.RowGroups() {
 				rg := buf.DynamicRowGroup(i)
 				var mayContainUsefulData bool
 				mayContainUsefulData, err = filter.Eval(rg)


### PR DESCRIPTION
This PR is intended to bring the latest changes from segmentio/parquet-go to arcticdb.

Currently it has a reference to https://github.com/segmentio/parquet-go/pull/172 but once the pull request is merged the reference should be changed to point at the main branch again.

There are places where the code might not be the most expressive or efficient due to the changing APIs, I did not want to modify the exported APIs of arcticdb since I don't have great visibility about what software may have taken dependencies on them nor how much work it would incur to change them.

The code builds and the tests pass, which is what I wanted to validate.

Please let me know if there is something you would like me to change.