### PR TITLE
fix query schema not hard-coded

### DIFF
--- a/query/engine.go
+++ b/query/engine.go
@@ -6,7 +6,6 @@ import (
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/memory"
 
-	"github.com/polarsignals/arcticdb/dynparquet"
 	"github.com/polarsignals/arcticdb/query/logicalplan"
 	"github.com/polarsignals/arcticdb/query/physicalplan"
 )
@@ -106,7 +105,7 @@ func (b LocalQueryBuilder) Execute(ctx context.Context, callback func(r arrow.Re
 
 	phyPlan, err := physicalplan.Build(
 		b.pool,
-		dynparquet.NewSampleSchema(),
+		logicalPlan.InputSchema(),
 		logicalPlan,
 	)
 	if err != nil {

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -1,0 +1,92 @@
+package logicalplan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/polarsignals/arcticdb/dynparquet"
+)
+
+type mockTableReader struct {
+	schema *dynparquet.Schema
+}
+
+func (m *mockTableReader) Schema() *dynparquet.Schema {
+	return m.schema
+}
+
+func (m *mockTableReader) Iterator(
+	ctx context.Context,
+	pool memory.Allocator,
+	projection []ColumnMatcher,
+	filter Expr,
+	distinctColumns []ColumnMatcher,
+	callback func(r arrow.Record) error,
+) error {
+	return nil
+}
+
+func (m *mockTableReader) SchemaIterator(
+	ctx context.Context,
+	pool memory.Allocator,
+	projection []ColumnMatcher,
+	filter Expr,
+	distinctColumns []ColumnMatcher,
+	callback func(r arrow.Record) error,
+) error {
+	return nil
+}
+
+type mockTableProvider struct {
+	schema *dynparquet.Schema
+}
+
+func (m *mockTableProvider) GetTable(name string) TableReader {
+	return &mockTableReader{
+		schema: m.schema,
+	}
+}
+
+func TestInputSchemaGetter(t *testing.T) {
+	schema := dynparquet.NewSampleSchema()
+
+	// test we can get the table by traversing to find the TableScan
+	plan := (&Builder{}).
+		Scan(&mockTableProvider{schema}, "table1").
+		Filter(Col("labels.test").Eq(Literal("abc"))).
+		Aggregate(
+			Sum(Col("value")).Alias("value_sum"),
+			Col("stacktrace"),
+		).
+		Project(Col("stacktrace")).
+		Build()
+	require.Equal(t, schema, plan.InputSchema())
+
+	// test we can get the table by traversing to find SchemaScan
+	plan = (&Builder{}).
+		ScanSchema(&mockTableProvider{schema}, "table1").
+		Filter(Col("labels.test").Eq(Literal("abc"))).
+		Aggregate(
+			Sum(Col("value")).Alias("value_sum"),
+			Col("stacktrace"),
+		).
+		Project(Col("stacktrace")).
+		Build()
+	require.Equal(t, schema, plan.InputSchema())
+
+	// test it returns null in case where we built a logical plan w/ no
+	// TableScan or SchemaScan
+	plan = (&Builder{}).
+		Filter(Col("labels.test").Eq(Literal("abc"))).
+		Aggregate(
+			Sum(Col("value")).Alias("value_sum"),
+			Col("stacktrace"),
+		).
+		Project(Col("stacktrace")).
+		Build()
+	require.Nil(t, plan.InputSchema())
+}


### PR DESCRIPTION
fixes issue in query/engine.go where the schema passed to the physical plan builder was hard-coded to the sample schema.

It now gets the schema from the logical plan. A new method was added to the logcal plan to return the schema which traverses the tree to get the schema from the TableProvider on either TableScan or SchemaScan steps.

A new method was also added to the TableReader interface which returns the schema