### PR TITLE
Fix 59 concurrency

### DIFF
--- a/part_list.go
+++ b/part_list.go
@@ -80,11 +80,15 @@ func (l *PartList) Iterate(iterate func(*Part) bool) {
 		if node == nil {
 			return
 		}
-		if node.part == nil && node.sentinel != l.listType { // if we've encountererd a sentinel node from a different type of list we must exit
-			return
-		}
-		if node.part != nil && !iterate(node.part) { // if the part == nil then this is a sentinel node, and we can skip it
-			return
+		switch node.part {
+		case nil: // sentinel node
+			if l.listType != None && node.sentinel != l.listType { // if we've encountererd a sentinel node from a different type of list we must exit
+				return
+			}
+		default: // normal node
+			if !iterate(node.part) { // if the part == nil then this is a sentinel node, and we can skip it
+				return
+			}
 		}
 		next = node.next.Load()
 	}

--- a/table_test.go
+++ b/table_test.go
@@ -436,7 +436,6 @@ func Test_Table_Concurrency(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			table := basicTable(t, test.granuleSize)
 
 			generateRows := func(n int) *dynparquet.Buffer {

--- a/table_test.go
+++ b/table_test.go
@@ -425,74 +425,88 @@ func Test_Table_InsertLowest(t *testing.T) {
 
 // This test issues concurrent writes to the database, and expects all of them to be recorded successfully.
 func Test_Table_Concurrency(t *testing.T) {
-	table := basicTable(t, 1<<13)
-
-	generateRows := func(n int) *dynparquet.Buffer {
-		rows := make(dynparquet.Samples, 0, n)
-		for i := 0; i < n; i++ {
-			rows = append(rows, dynparquet.Sample{
-				Labels: []dynparquet.Label{ // TODO would be nice to not have all the same column
-					{Name: "label1", Value: "value1"},
-					{Name: "label2", Value: "value2"},
-				},
-				Stacktrace: []uuid.UUID{
-					{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
-					{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
-				},
-				Timestamp: rand.Int63(),
-				Value:     rand.Int63(),
-			})
-		}
-		buf, err := rows.ToBuffer(table.Schema())
-		require.NoError(t, err)
-
-		buf.Sort()
-
-		// This is necessary because sorting a buffer makes concurrent reading not
-		// safe as the internal pages are cyclically sorted at read time. Cloning
-		// executes the cyclic sort once and makes the resulting buffer safe for
-		// concurrent reading as it no longer has to perform the cyclic sorting at
-		// read time. This should probably be improved in the parquet library.
-		buf, err = buf.Clone()
-		require.NoError(t, err)
-
-		return buf
+	tests := map[string]struct {
+		granuleSize int
+	}{
+		"8192": {8192},
+		"4096": {4096},
+		"2048": {2048},
+		"1024": {1024},
 	}
 
-	// Spawn n workers that will insert values into the table
-	n := 8
-	inserts := 100
-	rows := 10
-	wg := &sync.WaitGroup{}
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for i := 0; i < inserts; i++ {
-				if _, err := table.InsertBuffer(generateRows(rows)); err != nil {
-					fmt.Println("Received error on insert: ", err)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			table := basicTable(t, test.granuleSize)
+
+			generateRows := func(n int) *dynparquet.Buffer {
+				rows := make(dynparquet.Samples, 0, n)
+				for i := 0; i < n; i++ {
+					rows = append(rows, dynparquet.Sample{
+						Labels: []dynparquet.Label{ // TODO would be nice to not have all the same column
+							{Name: "label1", Value: "value1"},
+							{Name: "label2", Value: "value2"},
+						},
+						Stacktrace: []uuid.UUID{
+							{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+							{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+						},
+						Timestamp: rand.Int63(),
+						Value:     rand.Int63(),
+					})
 				}
+				buf, err := rows.ToBuffer(table.Schema())
+				require.NoError(t, err)
+
+				buf.Sort()
+
+				// This is necessary because sorting a buffer makes concurrent reading not
+				// safe as the internal pages are cyclically sorted at read time. Cloning
+				// executes the cyclic sort once and makes the resulting buffer safe for
+				// concurrent reading as it no longer has to perform the cyclic sorting at
+				// read time. This should probably be improved in the parquet library.
+				buf, err = buf.Clone()
+				require.NoError(t, err)
+
+				return buf
 			}
-		}()
+
+			// Spawn n workers that will insert values into the table
+			n := 8
+			inserts := 100
+			rows := 10
+			wg := &sync.WaitGroup{}
+			for i := 0; i < n; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for i := 0; i < inserts; i++ {
+						if _, err := table.InsertBuffer(generateRows(rows)); err != nil {
+							fmt.Println("Received error on insert: ", err)
+						}
+					}
+				}()
+			}
+
+			wg.Wait()
+			table.Sync()
+
+			// Sync has happened so all transactions are complete. We should be able to wait unti the watermark is equal to the the number of tx
+			for watermark := table.db.highWatermark.Load(); watermark < uint64(n*inserts); watermark = table.db.highWatermark.Load() {
+				time.Sleep(time.Millisecond)
+			}
+
+			totalrows := int64(0)
+			err := table.Iterator(context.Background(), memory.NewGoAllocator(), nil, nil, nil, func(ar arrow.Record) error {
+				totalrows += ar.NumRows()
+				defer ar.Release()
+
+				return nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, int64(n*inserts*rows), totalrows)
+		})
 	}
-
-	wg.Wait()
-	table.Sync()
-
-	// Sync has happened so all transactions are complete. We should be able to wait unti the watermark is equal to the the number of tx
-	for watermark := table.db.highWatermark.Load(); watermark < uint64(n*inserts); watermark = table.db.highWatermark.Load() {
-		time.Sleep(time.Millisecond)
-	}
-
-	totalrows := int64(0)
-	err := table.Iterator(context.Background(), memory.NewGoAllocator(), nil, nil, nil, func(ar arrow.Record) error {
-		totalrows += ar.NumRows()
-		defer ar.Release()
-
-		return nil
-	})
-	require.NoError(t, err)
-	require.Equal(t, int64(n*inserts*rows), totalrows)
 }
 
 //func Benchmark_Table_Insert_10Rows_10Iter_10Writers(b *testing.B) {


### PR DESCRIPTION
This fixes the issue detailed in #59 

We now iterate over all parts in a part list when the listType is None which happens during queries of the table.
It also fixes the unit test to wait for the txPool to drain instead of assuming we know how many tx the system has.