### PR TITLE
Issue 54 abort writes

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -70,7 +70,7 @@ func TestAggregate(t *testing.T) {
 	buf, err := samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	// Ensure all transactions are completed
@@ -152,7 +152,7 @@ func TestAggregateNils(t *testing.T) {
 	buf, err := samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	engine := query.NewEngine(
@@ -232,7 +232,7 @@ func TestAggregateInconsistentSchema(t *testing.T) {
 		buf, err := samples[i : i+1].ToBuffer(table.Schema())
 		require.NoError(t, err)
 
-		_, err = table.InsertBuffer(buf)
+		_, err = table.InsertBuffer(context.Background(), buf)
 		require.NoError(t, err)
 	}
 

--- a/distinct_test.go
+++ b/distinct_test.go
@@ -69,7 +69,7 @@ func TestDistinct(t *testing.T) {
 	buf, err := samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	tests := map[string]struct {
@@ -163,7 +163,7 @@ func TestDistinctProjection(t *testing.T) {
 	buf, err := samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	engine := query.NewEngine(

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -56,7 +56,7 @@ func main() {
 		parquet.ValueOf("Hansen").Level(0, 1, 1),
 		parquet.ValueOf(10).Level(0, 0, 2),
 	})
-	table.InsertBuffer(buf)
+	table.InsertBuffer(context.Background(), buf)
 
 	// Now we can insert rows that have middle names into our dynamic column
 	buf, _ = schema.NewBuffer(map[string][]string{
@@ -69,7 +69,7 @@ func main() {
 		parquet.ValueOf("Loibl").Level(0, 1, 2),
 		parquet.ValueOf(1).Level(0, 0, 3),
 	})
-	table.InsertBuffer(buf)
+	table.InsertBuffer(context.Background(), buf)
 
 	// Create a new query engine to retrieve data and print the results
 	engine := query.NewEngine(memory.DefaultAllocator, database.TableProvider())

--- a/filter_test.go
+++ b/filter_test.go
@@ -70,7 +70,7 @@ func TestFilter(t *testing.T) {
 		buf, err := samples[i : i+1].ToBuffer(table.Schema())
 		require.NoError(t, err)
 
-		_, err = table.InsertBuffer(buf)
+		_, err = table.InsertBuffer(context.Background(), buf)
 		require.NoError(t, err)
 	}
 

--- a/table.go
+++ b/table.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"sync"
 	"unsafe"
 
@@ -183,16 +184,16 @@ func (t *Table) Sync() {
 	t.ActiveBlock().Sync()
 }
 
-func (t *Table) InsertBuffer(buf *dynparquet.Buffer) (uint64, error) {
-	b, err := t.config.schema.SerializeBuffer(buf)
+func (t *Table) InsertBuffer(ctx context.Context, buf *dynparquet.Buffer) (uint64, error) {
+	b, err := t.config.schema.SerializeBuffer(buf) // TODO should we abort this function? If a large buffer is passed this could get long potentially...
 	if err != nil {
 		return 0, fmt.Errorf("serialize buffer: %w", err)
 	}
 
-	return t.Insert(b)
+	return t.Insert(ctx, b)
 }
 
-func (t *Table) Insert(buf []byte) (uint64, error) {
+func (t *Table) Insert(ctx context.Context, buf []byte) (uint64, error) {
 	tx, _, commit := t.db.begin()
 	defer commit()
 
@@ -202,7 +203,7 @@ func (t *Table) Insert(buf []byte) (uint64, error) {
 	}
 
 	block := t.ActiveBlock()
-	err = block.Insert(tx, serBuf)
+	err = block.Insert(ctx, tx, serBuf)
 	if err != nil {
 		return 0, err
 	}
@@ -365,7 +366,7 @@ func (t *TableBlock) Sync() {
 	t.wg.Wait()
 }
 
-func (t *TableBlock) Insert(tx uint64, buf *dynparquet.SerializedBuffer) error {
+func (t *TableBlock) Insert(ctx context.Context, tx uint64, buf *dynparquet.SerializedBuffer) error {
 	defer func() {
 		t.table.metrics.rowsInserted.Add(float64(buf.NumRows()))
 		t.table.metrics.rowInsertSize.Observe(float64(buf.NumRows()))
@@ -381,16 +382,25 @@ func (t *TableBlock) Insert(tx uint64, buf *dynparquet.SerializedBuffer) error {
 		return fmt.Errorf("failed to split rows by granule: %w", err)
 	}
 
+	parts := []*Part{}
 	for granule, serBuf := range rowsToInsertPerGranule {
-		card, err := granule.AddPart(NewPart(tx, serBuf))
-		if err != nil {
-			return fmt.Errorf("failed to add part to granule: %w", err)
+		select {
+		case <-ctx.Done():
+			tombstone(parts)
+			return ctx.Err()
+		default:
+			part := NewPart(tx, serBuf)
+			card, err := granule.AddPart(part)
+			if err != nil {
+				return fmt.Errorf("failed to add part to granule: %w", err)
+			}
+			parts = append(parts, part)
+			if card >= uint64(t.table.db.columnStore.granuleSize) {
+				t.wg.Add(1)
+				go t.compact(granule)
+			}
+			t.size.Add(serBuf.ParquetFile().Size())
 		}
-		if card >= uint64(t.table.db.columnStore.granuleSize) {
-			t.wg.Add(1)
-			go t.compact(granule)
-		}
-		t.size.Add(serBuf.ParquetFile().Size())
 	}
 
 	return nil
@@ -416,12 +426,12 @@ func (t *TableBlock) splitGranule(granule *Granule) {
 	parts.Iterate(func(p *Part) bool {
 		// Don't merge uncompleted transactions
 		if p.tx > watermark {
-			remain = append(remain, p)
+			if p.tx < math.MaxUint64 { // drop tombstoned parts
+				remain = append(remain, p)
+			}
 			return true
 		}
 
-		// TODO: should there be a method on p.Buf to get the list of dynamic
-		// row groups instead of having to do this conversion?
 		for i, n := 0, p.Buf.NumRowGroups(); i < n; i++ {
 			bufs = append(bufs, p.Buf.DynamicRowGroup(i))
 		}
@@ -955,4 +965,12 @@ func findColumnValues(matchers []logicalplan.ColumnMatcher, g *Granule) (*parque
 	g.metadata.maxlock.RUnlock()
 
 	return min, max, true
+}
+
+// tombstone marks all the parts with the max tx id to ensure they aren't included in reads.
+// Tombstoned parts will be eventually dropped from the database during compaction.
+func tombstone(parts []*Part) {
+	for _, part := range parts {
+		part.tx = math.MaxUint64
+	}
 }

--- a/table_test.go
+++ b/table_test.go
@@ -1111,7 +1111,6 @@ func Test_Table_InsertCancellation(t *testing.T) {
 }
 
 func Test_Table_CancelBasic(t *testing.T) {
-
 	table := basicTable(t, 8192)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/table_test.go
+++ b/table_test.go
@@ -100,7 +100,7 @@ func TestTable(t *testing.T) {
 	buf, err := samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	samples = dynparquet.Samples{{
@@ -120,7 +120,7 @@ func TestTable(t *testing.T) {
 	buf, err = samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	samples = dynparquet.Samples{{
@@ -141,7 +141,7 @@ func TestTable(t *testing.T) {
 	buf, err = samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	err = table.Iterator(context.Background(), memory.NewGoAllocator(), nil, nil, nil, func(ar arrow.Record) error {
@@ -218,7 +218,7 @@ func Test_Table_GranuleSplit(t *testing.T) {
 	buf, err := samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	samples = dynparquet.Samples{{
@@ -237,7 +237,7 @@ func Test_Table_GranuleSplit(t *testing.T) {
 	buf, err = samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	samples = dynparquet.Samples{{
@@ -257,7 +257,7 @@ func Test_Table_GranuleSplit(t *testing.T) {
 	buf, err = samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	// Wait for the index to be updated by the asynchronous granule split.
@@ -351,7 +351,7 @@ func Test_Table_InsertLowest(t *testing.T) {
 
 	// Since we are inserting 4 elements and the granule size is 4, the granule
 	// will immediately split.
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	// Since a compaction happens async, it may abort if it runs before the transactions are completed. In that case; we'll manually compact the granule
@@ -381,7 +381,7 @@ func Test_Table_InsertLowest(t *testing.T) {
 	buf, err = samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	// Wait for the index to be updated by the asynchronous granule split.
@@ -407,7 +407,7 @@ func Test_Table_InsertLowest(t *testing.T) {
 	buf, err = samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	// Wait for the index to be updated by the asynchronous granule split.
@@ -482,7 +482,7 @@ func Test_Table_Concurrency(t *testing.T) {
 				go func() {
 					defer wg.Done()
 					for i := 0; i < inserts; i++ {
-						tx, err := table.InsertBuffer(generateRows(rows))
+						tx, err := table.InsertBuffer(context.Background(), generateRows(rows))
 						if err != nil {
 							fmt.Println("Received error on insert: ", err)
 						}
@@ -646,7 +646,7 @@ func Test_Table_ReadIsolation(t *testing.T) {
 	buf, err := samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	// Perform a new insert that will have a higher tx id
@@ -666,7 +666,7 @@ func Test_Table_ReadIsolation(t *testing.T) {
 	buf, err = samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	tx, err := table.InsertBuffer(buf)
+	tx, err := table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	table.db.Wait(tx)
@@ -953,7 +953,7 @@ func Test_Table_Filter(t *testing.T) {
 	buf, err := samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	samples = dynparquet.Samples{{
@@ -973,7 +973,7 @@ func Test_Table_Filter(t *testing.T) {
 	buf, err = samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	samples = dynparquet.Samples{{
@@ -994,7 +994,7 @@ func Test_Table_Filter(t *testing.T) {
 	buf, err = samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	_, err = table.InsertBuffer(buf)
+	_, err = table.InsertBuffer(context.Background(), buf)
 	require.NoError(t, err)
 
 	filterExpr := logicalplan.And( // Filter that excludes the granule

--- a/table_test.go
+++ b/table_test.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/memory"


### PR DESCRIPTION
Write cancellation. Addresses #54 

On context cancellation we'll mark all parts that have been written with a tombstone transaction id (`math.MaxUint64`) which causes them to be ignored during reads. They'll eventually be reaped during compaction and not be copied into the next granules.