### PR TITLE
WIP fix(62): Add validation of logicalplan

### DIFF
--- a/query/engine.go
+++ b/query/engine.go
@@ -90,7 +90,10 @@ func (b LocalQueryBuilder) Project(
 }
 
 func (b LocalQueryBuilder) Execute(ctx context.Context, callback func(r arrow.Record) error) error {
-	logicalPlan := b.planBuilder.Build()
+	logicalPlan, err := b.planBuilder.Build()
+	if err != nil {
+		return err
+	}
 
 	optimizers := []logicalplan.Optimizer{
 		&logicalplan.PhysicalProjectionPushDown{},

--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -135,6 +135,9 @@ func (b Builder) Aggregate(
 	}
 }
 
-func (b Builder) Build() *LogicalPlan {
-	return b.plan
+func (b Builder) Build() (*LogicalPlan, error) {
+	if err := Validate(b.plan); err != nil {
+		return nil, err
+	}
+	return b.plan, nil
 }

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -55,7 +55,7 @@ func TestInputSchemaGetter(t *testing.T) {
 	schema := dynparquet.NewSampleSchema()
 
 	// test we can get the table by traversing to find the TableScan
-	plan := (&Builder{}).
+	plan, _ := (&Builder{}).
 		Scan(&mockTableProvider{schema}, "table1").
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
@@ -67,7 +67,7 @@ func TestInputSchemaGetter(t *testing.T) {
 	require.Equal(t, schema, plan.InputSchema())
 
 	// test we can get the table by traversing to find SchemaScan
-	plan = (&Builder{}).
+	plan, _ = (&Builder{}).
 		ScanSchema(&mockTableProvider{schema}, "table1").
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
@@ -80,7 +80,7 @@ func TestInputSchemaGetter(t *testing.T) {
 
 	// test it returns null in case where we built a logical plan w/ no
 	// TableScan or SchemaScan
-	plan = (&Builder{}).
+	plan, _ = (&Builder{}).
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
 			Sum(Col("value")).Alias("value_sum"),

--- a/query/logicalplan/validate.go
+++ b/query/logicalplan/validate.go
@@ -1,0 +1,310 @@
+package logicalplan
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/apache/arrow/go/v8/arrow/scalar"
+	"github.com/segmentio/parquet-go/format"
+)
+
+// PlanValidationError is the error representing a logical plan that is not valid.
+type PlanValidationError struct {
+	message  string
+	plan     *LogicalPlan
+	children []*ExprValidationError
+	input    *PlanValidationError
+}
+
+// PlanValidationError.Error prints the error message in a human-readable format.
+// implements the error interface.
+func (e *PlanValidationError) Error() string {
+	message := make([]string, 0)
+	message = append(message, e.message)
+	message = append(message, "\n")
+	message = append(message, fmt.Sprintf("%s", e.plan))
+
+	for _, child := range e.children {
+		message = append(message, "\n  -> invalid expression: ")
+		message = append(message, child.Error())
+		message = append(message, "\n")
+	}
+
+	if e.input != nil {
+		message = append(message, "-> invalid input: ")
+		message = append(message, e.input.Error())
+	}
+
+	return strings.Join(message, "")
+}
+
+// ExprValidationError is the error for an invalid expression that was found during validation.
+type ExprValidationError struct {
+	message  string
+	expr     Expr
+	children []*ExprValidationError
+}
+
+// ExprValidationError.Error prints the error message in a human-readable format.
+// implements the error interface.
+func (e *ExprValidationError) Error() string {
+	message := make([]string, 0)
+	message = append(message, e.message)
+	message = append(message, ": ")
+	message = append(message, fmt.Sprintf("%s", e.expr))
+	for _, child := range e.children {
+		message = append(message, "\n     -> invalid sub-expression: ")
+		message = append(message, child.Error())
+	}
+
+	return strings.Join(message, "")
+}
+
+// Validate validates the logical plan.
+func Validate(plan *LogicalPlan) error {
+	err := ValidateSingleFieldSet(plan)
+	if err == nil {
+		switch {
+		case plan.SchemaScan != nil:
+			err = nil
+		case plan.TableScan != nil:
+			err = nil
+		case plan.Filter != nil:
+			err = ValidateFilter(plan)
+		case plan.Distinct != nil:
+			err = nil
+		case plan.Projection != nil:
+			err = nil
+		case plan.Aggregation != nil:
+			err = nil
+		}
+	}
+
+	// traverse backwards up the plan to validate all inputs
+	inputErr := ValidateInput(plan)
+	if inputErr != nil {
+		if err == nil {
+			err = inputErr
+		} else {
+			err.input = inputErr
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateSingleFieldSet checks that only a single field is set on the plan.
+func ValidateSingleFieldSet(plan *LogicalPlan) *PlanValidationError {
+	fieldsSet := make([]int, 0)
+	if plan.SchemaScan != nil {
+		fieldsSet = append(fieldsSet, 0)
+	}
+	if plan.TableScan != nil {
+		fieldsSet = append(fieldsSet, 1)
+	}
+	if plan.Filter != nil {
+		fieldsSet = append(fieldsSet, 2)
+	}
+	if plan.Distinct != nil {
+		fieldsSet = append(fieldsSet, 3)
+	}
+	if plan.Projection != nil {
+		fieldsSet = append(fieldsSet, 4)
+	}
+	if plan.Aggregation != nil {
+		fieldsSet = append(fieldsSet, 5)
+	}
+
+	if len(fieldsSet) != 1 {
+		fieldsFound := make([]string, 0)
+		fields := []string{"SchemaScan", "TableScan", "Filter", "Distinct", "Projection", "Aggregation"}
+		for _, i := range fieldsSet {
+			fieldsFound = append(fieldsFound, fields[i])
+		}
+
+		message := make([]string, 0)
+		message = append(message,
+			fmt.Sprintf("invalid number of fields. expected: 1, found: %d (%s). plan must only have one of the following: ",
+				len(fieldsSet),
+				strings.Join(fieldsFound, ", "),
+			),
+		)
+		message = append(message, strings.Join(fields, ", "))
+
+		return &PlanValidationError{
+			plan:    plan,
+			message: strings.Join(message, ""),
+		}
+	}
+	return nil
+}
+
+// ValidateInput validates that the current logical plans input is valid.
+// It returns nil if the plan has no input.
+func ValidateInput(plan *LogicalPlan) *PlanValidationError {
+	if plan.Input != nil {
+		inputErr := Validate(plan.Input)
+		if inputErr != nil {
+			inputValidationErr, ok := inputErr.(*PlanValidationError)
+			if !ok {
+				// if we are here it is a bug in the code
+				panic(fmt.Sprintf("Unexpected error: %v expected a PlanValidationError", inputErr))
+			}
+			return inputValidationErr
+		}
+	}
+	return nil
+}
+
+// ValidateFilter validates the logical plan's filter step.
+func ValidateFilter(plan *LogicalPlan) *PlanValidationError {
+	if err := ValidateFilterExpr(plan, plan.Filter.Expr); err != nil {
+		return &PlanValidationError{
+			message:  "invalid filter",
+			plan:     plan,
+			children: []*ExprValidationError{err},
+		}
+	}
+	return nil
+}
+
+// ValidateFilterExpr validates filter's expression.
+func ValidateFilterExpr(plan *LogicalPlan, e Expr) *ExprValidationError {
+	switch expr := e.(type) {
+	case BinaryExpr:
+		err := ValidateFilterBinaryExpr(plan, &expr)
+		return err
+	}
+
+	return nil
+}
+
+// ValidateFilterBinaryExpr validates the filter's binary expression.
+func ValidateFilterBinaryExpr(plan *LogicalPlan, expr *BinaryExpr) *ExprValidationError {
+	if expr.Op == AndOp {
+		return ValidateFilterAndBinaryExpr(plan, expr)
+	}
+
+	// try to find the column expression on the left side of the binary expression
+	leftColumnFinder := newTypeFinder((*Column)(nil))
+	expr.Left.Accept(&leftColumnFinder)
+	if leftColumnFinder.result == nil {
+		return &ExprValidationError{
+			message: "left side of binary expression must be a column",
+			expr:    expr,
+		}
+	}
+
+	// try to find the column in the schema
+	columnExpr := leftColumnFinder.result.(Column)
+	schema := plan.InputSchema()
+	if schema != nil {
+		column, found := schema.ColumnByName(columnExpr.ColumnName)
+		if found {
+			// try to find the literal on the other side of the expression
+			rightLiteralFinder := newTypeFinder((*LiteralExpr)(nil))
+			expr.Right.Accept(&rightLiteralFinder)
+			if rightLiteralFinder.result != nil {
+				// ensure that the column type is compatible with the literal being compared to it
+				t := column.StorageLayout.Type()
+				literalExpr := rightLiteralFinder.result.(LiteralExpr)
+				if err := ValidateComparingTypes(t.LogicalType(), literalExpr.Value); err != nil {
+					err.expr = expr
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateComparingTypes validates if the types being compared by a binary expression are compatible.
+func ValidateComparingTypes(columnType *format.LogicalType, literal scalar.Scalar) *ExprValidationError {
+	switch {
+	// if the column is a string type, it shouldn't be compared to a number
+	case columnType.UTF8 != nil:
+		switch literal.(type) {
+		case *scalar.Float64:
+			return &ExprValidationError{
+				message: "incompatible types: string column cannot be compared with numeric literal",
+			}
+		case *scalar.Int64:
+			return &ExprValidationError{
+				message: "incompatible types: string column cannot be compared with numeric literal",
+			}
+		}
+	// if the column is a numeric type, it shouldn't be compared to a string
+	case columnType.Integer != nil:
+		switch literal.(type) {
+		case *scalar.String:
+			return &ExprValidationError{
+				message: "incompatible types: numeric column cannot be compared with string literal",
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateFilterAndBinaryExpr validates the filter's binary expression where Op = AND.
+func ValidateFilterAndBinaryExpr(plan *LogicalPlan, expr *BinaryExpr) *ExprValidationError {
+	leftErr := ValidateFilterExpr(plan, expr.Left)
+	rightErr := ValidateFilterExpr(plan, expr.Right)
+
+	if leftErr != nil || rightErr != nil {
+		message := make([]string, 0, 3)
+		message = append(message, "invalid children:")
+
+		validationErr := ExprValidationError{
+			expr:     expr,
+			children: make([]*ExprValidationError, 0),
+		}
+
+		if leftErr != nil {
+			lve := leftErr
+			message = append(message, "left")
+			validationErr.children = append(validationErr.children, lve)
+		}
+
+		if rightErr != nil {
+			lve := rightErr
+			message = append(message, "right")
+			validationErr.children = append(validationErr.children, lve)
+		}
+
+		validationErr.message = strings.Join(message, " ")
+		return &validationErr
+	}
+	return nil
+}
+
+// NewTypeFinder returns an instance of the findExpressionForTypeVisitor for the
+// passed type. It expects to receive a pointer to the  type it is will find.
+func newTypeFinder(val interface{}) findExpressionForTypeVisitor {
+	return findExpressionForTypeVisitor{exprType: reflect.TypeOf(val).Elem()}
+}
+
+// findExpressionForTypeVisitor is an instance of Visitor that will try to find
+// an expression of the given type while visiting the expressions.
+type findExpressionForTypeVisitor struct {
+	exprType reflect.Type
+	// if an expression of the type is found, it will be set on this field after
+	// visiting. Other-wise this field will be null
+	result Expr
+}
+
+func (v *findExpressionForTypeVisitor) PreVisit(expr Expr) bool {
+	return true
+}
+
+func (v *findExpressionForTypeVisitor) PostVisit(expr Expr) bool {
+	found := v.exprType == reflect.TypeOf(expr)
+	if found {
+		v.result = expr
+	}
+	return !found
+}

--- a/query/logicalplan/validate_test.go
+++ b/query/logicalplan/validate_test.go
@@ -1,0 +1,149 @@
+package logicalplan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/polarsignals/arcticdb/dynparquet"
+)
+
+func TestOnlyOneFieldCanBeSet(t *testing.T) {
+	plan := LogicalPlan{
+		Filter: &Filter{
+			Expr: BinaryExpr{
+				Left:  Col("example_type"),
+				Op:    EqOp,
+				Right: Literal(4),
+			},
+		},
+		TableScan: &TableScan{
+			TableProvider: &mockTableProvider{dynparquet.NewSampleSchema()},
+			TableName:     "table1",
+		},
+	}
+
+	err := Validate(&plan)
+	require.NotNil(t, err)
+
+	planErr, ok := err.(*PlanValidationError)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(planErr.message, "invalid number of fields"))
+}
+
+func TestCanTraverseInputThatIsInvalid(t *testing.T) {
+	_, err := (&Builder{}).
+		Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
+		Filter(BinaryExpr{
+			Left:  Col("example_type"),
+			Op:    EqOp,
+			Right: Literal(4),
+		}).
+		Filter(BinaryExpr{
+			Left:  Col("stacktrace"),
+			Op:    EqOp,
+			Right: Literal(4),
+		}).
+		Build()
+
+	require.NotNil(t, err)
+	planErr, ok := err.(*PlanValidationError)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(planErr.message, "invalid filter"))
+
+	inputErr := planErr.input
+	require.NotNil(t, inputErr)
+	require.True(t, strings.HasPrefix(inputErr.message, "invalid filter"))
+}
+
+func TestFilterBinaryExprLeftSideMustBeColumn(t *testing.T) {
+	_, err := (&Builder{}).
+		Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
+		Filter(BinaryExpr{
+			Left:  Literal(5),
+			Op:    EqOp,
+			Right: Literal(4),
+		}).
+		Build()
+
+	planErr, ok := err.(*PlanValidationError)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(planErr.message, "invalid filter"))
+	require.Len(t, planErr.children, 1)
+	exprErr := planErr.children[0]
+	require.True(t, strings.HasPrefix(exprErr.message, "left side of binary expression must be a column"))
+}
+
+func TestFilterBinaryExprColMustMatchLiteralType(t *testing.T) {
+	_, err := (&Builder{}).
+		Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
+		Filter(BinaryExpr{
+			Left:  Col("example_type"),
+			Op:    EqOp,
+			Right: Literal(4.6),
+		}).
+		Build()
+
+	require.NotNil(t, err)
+	planErr, ok := err.(*PlanValidationError)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(planErr.message, "invalid filter"))
+	require.Len(t, planErr.children, 1)
+	exprErr := planErr.children[0]
+	require.True(t, strings.HasPrefix(exprErr.message, "incompatible types"))
+
+	// check that it also works the other way around, can't compare number w/ string
+	_, err = (&Builder{}).
+		Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
+		Filter(BinaryExpr{
+			Left:  Col("timestamp"),
+			Op:    EqOp,
+			Right: Literal("albert"),
+		}).
+		Build()
+	require.NotNil(t, err)
+	planErr, ok = err.(*PlanValidationError)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(planErr.message, "invalid filter"))
+	require.Len(t, planErr.children, 1)
+	exprErr = planErr.children[0]
+	require.True(t, strings.HasPrefix(exprErr.message, "incompatible types"))
+}
+
+func TestFilterAndExprEvaluatesEachAndedRule(t *testing.T) {
+	_, err := (&Builder{}).
+		Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
+		Filter(And(
+			BinaryExpr{
+				Left:  Col("example_type"),
+				Op:    EqOp,
+				Right: Literal(4),
+			},
+			BinaryExpr{
+				Left:  Literal("a"),
+				Op:    EqOp,
+				Right: Literal("b"),
+			},
+		)).
+		Build()
+
+	require.NotNil(t, err)
+	require.NotNil(t, err)
+	planErr, ok := err.(*PlanValidationError)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(planErr.message, "invalid filter"))
+	require.Len(t, planErr.children, 1)
+	exprErr := planErr.children[0]
+
+	require.True(t, strings.HasPrefix(exprErr.message, "invalid children:"))
+	require.True(t, strings.Contains(exprErr.message, "left"))
+	require.True(t, strings.Contains(exprErr.message, "right"))
+	require.Len(t, exprErr.children, 2)
+
+	leftErr := exprErr.children[0]
+	require.True(t, strings.HasPrefix(leftErr.message, "incompatible types"))
+
+	rightErr := exprErr.children[1]
+	require.True(t, strings.HasPrefix(rightErr.message, "left side of binary expression must be a column"))
+}


### PR DESCRIPTION
related issue: https://github.com/polarsignals/arcticdb/issues/62 (Filtering by the wrong literal type causes a panic)

Added code that validates the logicalplan. We can use this as the place where we'll add more business logic in the future.

For now the current business rules are only for filters and they are:
- the plan must only have one field set as stated here: https://github.com/polarsignals/arcticdb/blob/main/query/logicalplan/logicalplan.go#L19
- the left side of a binary expression must be a column
- the column type must match what is being compared with it (e.g string compared w/ string, number compared w/ number)
    
It has some basic capability to print errors in a way that is somewhat human readable - for example:
```golang
(&Builder{}).
Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
Filter(BinaryExpr{
	Left:  Literal(5),
	Op:    EqOp,
	Right: Literal(4),
}).
Build()
```
will print as:
```
invalid filter
Filter Expr: {{5} == {4}}
  TableScan Table: table1 Projection: [] Filter: <nil> Distinct: []
  -> invalid expression: left side of binary expression must be a column: &{{5} == {4}}
```