### PR TITLE
Replace array.Interface with arrow.Array

### DIFF
--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -159,7 +159,7 @@ func contiguousParquetRowGroupToArrowRecord(
 	}
 
 	fields := make([]arrow.Field, 0, len(parquetFields))
-	cols := make([]array.Interface, 0, len(parquetFields))
+	cols := make([]arrow.Array, 0, len(parquetFields))
 
 	for i, parquetField := range parquetFields {
 		select {


### PR DESCRIPTION
`array.Interface` is deprecated and removed by [this commit](https://github.com/apache/arrow/commit/61655b34f14e23fff217c314f60bbee92fe7961f).