### PR TITLE
Add nil check for t.LogicalType()

### DIFF
--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -372,6 +372,11 @@ func ParquetNodeToType(n parquet.Node) arrow.DataType {
 func parquetNodeToType(n parquet.Node) (arrow.DataType, func(b array.Builder, numValues int) valueWriter) {
 	t := n.Type()
 	lt := t.LogicalType()
+
+	if lt == nil {
+		panic("unsupported type")
+	}
+
 	switch {
 	case lt.UTF8 != nil:
 		return &arrow.BinaryType{}, newBinaryValueWriter


### PR DESCRIPTION
I noticed that the `LogicalType()` method returns nil for some Types.
https://github.com/segmentio/parquet-go/blob/4f4d804bcd3a5fe1a95bc1862ed8b126c5fea3de/type.go
https://github.com/segmentio/parquet-go/blob/4f4d804bcd3a5fe1a95bc1862ed8b126c5fea3de/type_go18.go
https://github.com/segmentio/parquet-go/blob/4f4d804bcd3a5fe1a95bc1862ed8b126c5fea3de/type_default.go
(The above URLs are a little older commits ArcticDB depends on. In the latest commit, they are in one file.)

When I first wrote and ran just the test, the results were as follows.
```
$ go test -run TestParquetNodeToType
--- FAIL: TestParquetNodeToType (0.00s)
    arrow_test.go:164: 
                Error Trace:    arrow_test.go:164
                Error:          func (assert.PanicTestFunc)(0x14dea80) should panic with value:       "unsupported type"
                                        Panic value:    "invalid memory address or nil pointer dereference"
                                        Panic stack:    goroutine 35 [running]:
                                runtime/debug.Stack()
                                        /usr/local/Cellar/go/1.18/libexec/src/runtime/debug/stack.go:24 +0x65
                                github.com/stretchr/testify/assert.didPanic.func1()
                                        /Users/nozomu/go/pkg/mod/github.com/stretchr/testify@v1.7.1/assert/assertions.go:1013 +0x6c
                                panic({0x15329a0, 0x1a30070})
                                        /usr/local/Cellar/go/1.18/libexec/src/runtime/panic.go:838 +0x207
                                github.com/polarsignals/arcticdb/pqarrow.parquetNodeToType({0x167a158?, 0xc000119670?})
                                        /Users/nozomu/projects/arcticdb/pqarrow/arrow.go:381 +0x34
                                github.com/polarsignals/arcticdb/pqarrow.ParquetNodeToType(...)
                                        /Users/nozomu/projects/arcticdb/pqarrow/arrow.go:366
                                github.com/polarsignals/arcticdb/pqarrow.TestParquetNodeToType.func1()
                                        /Users/nozomu/projects/arcticdb/pqarrow/arrow_test.go:164 +0x25
                                github.com/stretchr/testify/assert.didPanic(0xc000244000?)
                                        /Users/nozomu/go/pkg/mod/github.com/stretchr/testify@v1.7.1/assert/assertions.go:1018 +0x8c
                                github.com/stretchr/testify/assert.PanicsWithValue({0x1fa4438, 0xc000244000}, {0x1511d20?, 0xc000119680}, 0xc000119690, {0x0, 0x0, 0x0})
                                        /Users/nozomu/go/pkg/mod/github.com/stretchr/testify@v1.7.1/assert/assertions.go:1048 +0xa5
                                github.com/stretchr/testify/require.PanicsWithValue({0x1670c80, 0xc000244000}, {0x1511d20, 0xc000119680}, 0x1553000?, {0x0, 0x0, 0x0})
                                        /Users/nozomu/go/pkg/mod/github.com/stretchr/testify@v1.7.1/require/require.go:1666 +0xb6
                                github.com/polarsignals/arcticdb/pqarrow.TestParquetNodeToType(0x0?)
                                        /Users/nozomu/projects/arcticdb/pqarrow/arrow_test.go:164 +0x3f6
                                testing.tRunner(0xc000244000, 0x15d2bb0)
                                        /usr/local/Cellar/go/1.18/libexec/src/testing/testing.go:1439 +0x102
                                created by testing.(*T).Run
                                        /usr/local/Cellar/go/1.18/libexec/src/testing/testing.go:1486 +0x35f
                Test:           TestParquetNodeToType
FAIL
exit status 1
FAIL    github.com/polarsignals/arcticdb/pqarrow        0.153s
```