### PR TITLE
Upgrade parquet-go

### DIFF
--- a/dynparquet/concat.go
+++ b/dynparquet/concat.go
@@ -23,6 +23,6 @@ func (c *concatenatedDynamicRowGroup) DynamicColumns() map[string][]string {
 	return c.dynamicColumns
 }
 
-func (c *concatenatedDynamicRowGroup) DynamicRows() DynamicRows {
+func (c *concatenatedDynamicRowGroup) DynamicRows() DynamicRowReader {
 	return newDynamicRowGroupReader(c)
 }

--- a/dynparquet/reader.go
+++ b/dynparquet/reader.go
@@ -61,7 +61,7 @@ func (b *SerializedBuffer) NumRowGroups() int {
 	return len(b.f.RowGroups())
 }
 
-func (b *SerializedBuffer) DynamicRows() DynamicRows {
+func (b *SerializedBuffer) DynamicRows() DynamicRowReader {
 	rowGroups := b.f.RowGroups()
 	drg := make([]DynamicRowGroup, len(rowGroups))
 	for i, rowGroup := range rowGroups {
@@ -90,7 +90,7 @@ func (g *serializedRowGroup) DynamicColumns() map[string][]string {
 	return g.dynCols
 }
 
-func (g *serializedRowGroup) DynamicRows() DynamicRows {
+func (g *serializedRowGroup) DynamicRows() DynamicRowReader {
 	return newDynamicRowGroupReader(g)
 }
 

--- a/dynparquet/reader_test.go
+++ b/dynparquet/reader_test.go
@@ -25,6 +25,21 @@ func TestReader(t *testing.T) {
 
 	require.NoError(t, w.Close())
 
-	_, err = ReaderFromBytes(b.Bytes())
+	serBuf, err := ReaderFromBytes(b.Bytes())
 	require.NoError(t, err)
+	require.Equal(t, int64(3), serBuf.NumRows())
+}
+
+func TestSerializedReader(t *testing.T) {
+	schema := NewSampleSchema()
+	samples := NewTestSamples()
+	buf, err := samples.ToBuffer(schema)
+	require.NoError(t, err)
+
+	b, err := schema.SerializeBuffer(buf)
+	require.NoError(t, err)
+
+	serBuf, err := ReaderFromBytes(b)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), serBuf.NumRows())
 }

--- a/dynparquet/row.go
+++ b/dynparquet/row.go
@@ -4,6 +4,33 @@ import (
 	"github.com/segmentio/parquet-go"
 )
 
+type DynamicRows struct {
+	Rows           []parquet.Row
+	Schema         *parquet.Schema
+	DynamicColumns map[string][]string
+}
+
+func (r *DynamicRows) Get(i int) *DynamicRow {
+	return &DynamicRow{
+		Schema:         r.Schema,
+		DynamicColumns: r.DynamicColumns,
+		Row:            r.Rows[i],
+	}
+}
+
+func (r *DynamicRows) GetCopy(i int) *DynamicRow {
+	rowCopy := make(parquet.Row, len(r.Rows[i]))
+	for i, v := range r.Rows[i] {
+		rowCopy[i] = v.Clone()
+	}
+
+	return &DynamicRow{
+		Schema:         r.Schema,
+		DynamicColumns: r.DynamicColumns,
+		Row:            rowCopy,
+	}
+}
+
 type DynamicRow struct {
 	Row            parquet.Row
 	Schema         *parquet.Schema

--- a/dynparquet/row_test.go
+++ b/dynparquet/row_test.go
@@ -105,33 +105,39 @@ func TestLess(t *testing.T) {
 	}
 
 	var err error
-	row1 := &DynamicRow{
+	row1 := &DynamicRows{
 		Schema:         rowGroups[0].Schema(),
 		DynamicColumns: rowGroups[0].DynamicColumns(),
+		Rows:           make([]parquet.Row, 1),
 	}
-	row1.Row, err = rowGroups[0].Rows().ReadRow(nil)
+	n, err := rowGroups[0].Rows().ReadRows(row1.Rows)
 	require.NoError(t, err)
+	require.Equal(t, 1, n)
 
-	row2 := &DynamicRow{
+	row2 := &DynamicRows{
 		Schema:         rowGroups[1].Schema(),
 		DynamicColumns: rowGroups[1].DynamicColumns(),
+		Rows:           make([]parquet.Row, 1),
 	}
-	row2.Row, err = rowGroups[1].Rows().ReadRow(nil)
+	n, err = rowGroups[1].Rows().ReadRows(row2.Rows)
 	require.NoError(t, err)
+	require.Equal(t, 1, n)
 
-	row3 := &DynamicRow{
+	row3 := &DynamicRows{
 		Schema:         rowGroups[2].Schema(),
 		DynamicColumns: rowGroups[2].DynamicColumns(),
+		Rows:           make([]parquet.Row, 1),
 	}
-	row3.Row, err = rowGroups[2].Rows().ReadRow(nil)
+	n, err = rowGroups[2].Rows().ReadRows(row3.Rows)
 	require.NoError(t, err)
+	require.Equal(t, 1, n)
 
-	require.True(t, schema.RowLessThan(row1, row2))
-	require.True(t, schema.RowLessThan(row1, row3))
-	require.True(t, schema.RowLessThan(row2, row3))
-	require.False(t, schema.RowLessThan(row2, row1))
-	require.False(t, schema.RowLessThan(row3, row1))
-	require.False(t, schema.RowLessThan(row3, row2))
+	require.True(t, schema.RowLessThan(row1.Get(0), row2.Get(0)))
+	require.True(t, schema.RowLessThan(row1.Get(0), row3.Get(0)))
+	require.True(t, schema.RowLessThan(row2.Get(0), row3.Get(0)))
+	require.False(t, schema.RowLessThan(row2.Get(0), row1.Get(0)))
+	require.False(t, schema.RowLessThan(row3.Get(0), row1.Get(0)))
+	require.False(t, schema.RowLessThan(row3.Get(0), row2.Get(0)))
 }
 
 func TestLessWithDynamicSchemas(t *testing.T) {
@@ -167,20 +173,24 @@ func TestLessWithDynamicSchemas(t *testing.T) {
 	}
 
 	var err error
-	row1 := &DynamicRow{
+	row1 := &DynamicRows{
 		Schema:         rowGroups[0].Schema(),
 		DynamicColumns: rowGroups[0].DynamicColumns(),
+		Rows:           make([]parquet.Row, 1),
 	}
-	row1.Row, err = rowGroups[0].Rows().ReadRow(nil)
+	n, err := rowGroups[0].Rows().ReadRows(row1.Rows)
 	require.NoError(t, err)
+	require.Equal(t, 1, n)
 
-	row2 := &DynamicRow{
+	row2 := &DynamicRows{
 		Schema:         rowGroups[1].Schema(),
 		DynamicColumns: rowGroups[1].DynamicColumns(),
+		Rows:           make([]parquet.Row, 1),
 	}
-	row2.Row, err = rowGroups[1].Rows().ReadRow(nil)
+	n, err = rowGroups[1].Rows().ReadRows(row2.Rows)
 	require.NoError(t, err)
+	require.Equal(t, 1, n)
 
-	require.True(t, schema.RowLessThan(row2, row1))
-	require.False(t, schema.RowLessThan(row1, row2))
+	require.True(t, schema.RowLessThan(row2.Get(0), row1.Get(0)))
+	require.False(t, schema.RowLessThan(row1.Get(0), row2.Get(0)))
 }

--- a/dynparquet/schema_test.go
+++ b/dynparquet/schema_test.go
@@ -43,15 +43,24 @@ func TestMergeRowBatches(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that the first label column has the exected values.
+	rowBuf := make([]parquet.Row, 1)
 	rows := buf.Rows()
-	row, err := rows.ReadRow(nil)
+	n, err := rows.ReadRows(rowBuf)
 	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	row := rowBuf[0]
 	require.Equal(t, "test3", string(row[3].ByteArray()))
-	row, err = rows.ReadRow(nil)
+
+	n, err = rows.ReadRows(rowBuf)
 	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	row = rowBuf[0]
 	require.True(t, row[3].IsNull())
-	row, err = rows.ReadRow(nil)
+
+	n, err = rows.ReadRows(rowBuf)
 	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	row = rowBuf[0]
 	require.True(t, row[3].IsNull())
 }
 
@@ -194,21 +203,30 @@ func TestMultipleIterations(t *testing.T) {
 
 	buf := dbuf.buffer
 
+	rowBuf := make([]parquet.Row, 1)
 	rows := buf.Rows()
+	i := 0
 	for {
-		_, err := rows.ReadRow(nil)
+		n, err := rows.ReadRows(rowBuf)
 		if err == io.EOF {
 			break
 		}
 		require.NoError(t, err)
+		i += n
 	}
+	require.Equal(t, 3, i)
+	require.NoError(t, rows.Close())
 
 	rows = buf.Rows()
+	i = 0
 	for {
-		_, err := rows.ReadRow(nil)
+		n, err := rows.ReadRows(rowBuf)
 		if err == io.EOF {
 			break
 		}
 		require.NoError(t, err)
+		i += n
 	}
+	require.Equal(t, 3, i)
+	require.NoError(t, rows.Close())
 }

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -44,18 +44,18 @@ func main() {
 	})
 
 	// firstname:Frederic surname:Brancz 100
-	buf.WriteRow([]parquet.Value{
+	buf.WriteRows([]parquet.Row{{
 		parquet.ValueOf("Frederic").Level(0, 1, 0),
 		parquet.ValueOf("Brancz").Level(0, 1, 1),
 		parquet.ValueOf(100).Level(0, 0, 2),
-	})
+	}})
 
 	// firstname:Thor surname:Hansen 10
-	buf.WriteRow([]parquet.Value{
+	buf.WriteRows([]parquet.Row{{
 		parquet.ValueOf("Thor").Level(0, 1, 0),
 		parquet.ValueOf("Hansen").Level(0, 1, 1),
 		parquet.ValueOf(10).Level(0, 0, 2),
-	})
+	}})
 	table.InsertBuffer(context.Background(), buf)
 
 	// Now we can insert rows that have middle names into our dynamic column
@@ -63,12 +63,12 @@ func main() {
 		"names": {"firstname", "middlename", "surname"},
 	})
 	// firstname:Matthias middlename:Oliver surname:Loibl 1
-	buf.WriteRow([]parquet.Value{
+	buf.WriteRows([]parquet.Row{{
 		parquet.ValueOf("Matthias").Level(0, 1, 0),
 		parquet.ValueOf("Oliver").Level(0, 1, 1),
 		parquet.ValueOf("Loibl").Level(0, 1, 2),
 		parquet.ValueOf(1).Level(0, 0, 3),
-	})
+	}})
 	table.InsertBuffer(context.Background(), buf)
 
 	// Create a new query engine to retrieve data and print the results

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/btree v1.0.1
 	github.com/google/uuid v1.3.0
 	github.com/prometheus/client_golang v1.12.1
-	github.com/segmentio/parquet-go v0.0.0-20220511210326-4f4d804bcd3a
+	github.com/segmentio/parquet-go v0.0.0-20220524213358-0733add4c2cb
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/atomic v1.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,8 @@ github.com/segmentio/parquet-go v0.0.0-20220511171108-414f4f5a699b h1:xX4PMHxdkI
 github.com/segmentio/parquet-go v0.0.0-20220511171108-414f4f5a699b/go.mod h1:DMN6PChc8JaI7whze9XQn1aCv+8D7nhQKMfL8zXNjX4=
 github.com/segmentio/parquet-go v0.0.0-20220511210326-4f4d804bcd3a h1:GJ+IvAkKk++n419fRBbGhCUXENGIsxh89aAZTe3TJVM=
 github.com/segmentio/parquet-go v0.0.0-20220511210326-4f4d804bcd3a/go.mod h1:DMN6PChc8JaI7whze9XQn1aCv+8D7nhQKMfL8zXNjX4=
+github.com/segmentio/parquet-go v0.0.0-20220524213358-0733add4c2cb h1:3RITWgLOUct6jLN+fKbP6UrItkOTq1WWV7iMC4pPF4U=
+github.com/segmentio/parquet-go v0.0.0-20220524213358-0733add4c2cb/go.mod h1:DMN6PChc8JaI7whze9XQn1aCv+8D7nhQKMfL8zXNjX4=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/table_test.go
+++ b/table_test.go
@@ -169,8 +169,7 @@ func TestTable(t *testing.T) {
 		parquet.ValueOf("value2").Level(0, 1, 2),
 		parquet.ValueOf(nil).Level(0, 0, 3),
 		parquet.ValueOf(nil).Level(0, 0, 4),
-		parquet.ValueOf(uuid1[:]).Level(0, 1, 5),
-		parquet.ValueOf(uuid2[:]).Level(1, 1, 5),
+		parquet.ValueOf(append(uuid1[:], uuid2[:]...)).Level(0, 0, 5),
 		parquet.ValueOf(1).Level(0, 0, 6),
 		parquet.ValueOf(1).Level(0, 0, 7),
 	}, (*dynparquet.DynamicRow)(table.active.Index().Min().(*Granule).metadata.least.Load()).Row)
@@ -1026,7 +1025,7 @@ func Test_Table_InsertCancellation(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			table := basicTable(t, test.granuleSize)
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 			defer cancel()
 
 			generateRows := func(n int) *dynparquet.Buffer {


### PR DESCRIPTION
parquet-go recently broke its APIs to give users more control over memory management and allow batch reads and writes for more control of performance.

cc @thorfour 