### PR TITLE
Change DataType to return error

### DIFF
--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -79,7 +79,7 @@ func (m DynamicColumnMatcher) Match(columnName string) bool {
 }
 
 type Expr interface {
-	DataType(*dynparquet.Schema) arrow.DataType
+	DataType(*dynparquet.Schema) (arrow.DataType, error)
 	Accept(Visitor) bool
 	Name() string
 	ColumnsUsed() []ColumnMatcher

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -55,7 +55,12 @@ func Aggregate(
 		return nil, errors.New("aggregation column not found")
 	}
 
-	f, err := chooseAggregationFunction(aggFunc, agg.AggExpr.DataType(s))
+	dataType, err := agg.AggExpr.DataType(s)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := chooseAggregationFunction(aggFunc, dataType)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
close https://github.com/polarsignals/arcticdb/issues/75

`ParquetNodeToType` in logicalplan package was duplicated, so I changed to use the one in convert package.
`DataType` is changed accordingly to return error.

My main focus was to remove duplicate functions, but I thought the interface change is more significant from an external perspective, so this is what the commit message is.