### PR TITLE
query/logicalplan: Add filter marshalling

### DIFF
--- a/distinct_test.go
+++ b/distinct_test.go
@@ -187,6 +187,6 @@ func TestDistinctProjection(t *testing.T) {
 	require.NoError(t, err)
 	defer r.Release()
 
-	// t.Log(r)
+	t.Log(r)
 	require.Equal(t, int64(3), r.NumCols())
 }

--- a/distinct_test.go
+++ b/distinct_test.go
@@ -187,6 +187,6 @@ func TestDistinctProjection(t *testing.T) {
 	require.NoError(t, err)
 	defer r.Release()
 
-	t.Log(r)
+	// t.Log(r)
 	require.Equal(t, int64(3), r.NumCols())
 }

--- a/distinct_test.go
+++ b/distinct_test.go
@@ -173,7 +173,11 @@ func TestDistinctProjection(t *testing.T) {
 
 	var r arrow.Record
 	err = engine.ScanTable("test").
-		Distinct(logicalplan.Col("labels.label1"), logicalplan.Col("labels.label2"), logicalplan.Col("timestamp").GT(logicalplan.Literal(1))).
+		Distinct(
+			logicalplan.Col("labels.label1"),
+			logicalplan.Col("labels.label2"),
+			logicalplan.Col("timestamp").GT(logicalplan.Literal(1)),
+		).
 		Execute(context.Background(), func(ar arrow.Record) error {
 			ar.Retain()
 			r = ar

--- a/filter.go
+++ b/filter.go
@@ -48,7 +48,7 @@ func arrowScalarToParquetValue(sc scalar.Scalar) (parquet.Value, error) {
 	}
 }
 
-func binaryBooleanExpr(expr logicalplan.BinaryExpr) (TrueNegativeFilter, error) {
+func binaryBooleanExpr(expr *logicalplan.BinaryExpr) (TrueNegativeFilter, error) {
 	switch expr.Op {
 	case logicalplan.EqOp: //, logicalplan.NotEqOp, logicalplan.LTOp, logicalplan.LTEOp, logicalplan.GTOp, logicalplan.GTEOp, logicalplan.RegExpOp, logicalplan.NotRegExpOp:
 		var leftColumnRef *ColumnRef

--- a/filter.go
+++ b/filter.go
@@ -54,7 +54,7 @@ func binaryBooleanExpr(expr logicalplan.BinaryExpr) (TrueNegativeFilter, error) 
 		var leftColumnRef *ColumnRef
 		expr.Left.Accept(PreExprVisitorFunc(func(expr logicalplan.Expr) bool {
 			switch e := expr.(type) {
-			case logicalplan.Column:
+			case *logicalplan.Column:
 				leftColumnRef = &ColumnRef{
 					ColumnName: e.ColumnName,
 				}
@@ -72,7 +72,7 @@ func binaryBooleanExpr(expr logicalplan.BinaryExpr) (TrueNegativeFilter, error) 
 		)
 		expr.Right.Accept(PreExprVisitorFunc(func(expr logicalplan.Expr) bool {
 			switch e := expr.(type) {
-			case logicalplan.LiteralExpr:
+			case *logicalplan.LiteralExpr:
 				rightValue, err = arrowScalarToParquetValue(e.Value)
 				return false
 			}
@@ -137,7 +137,7 @@ func booleanExpr(expr logicalplan.Expr) (TrueNegativeFilter, error) {
 	}
 
 	switch e := expr.(type) {
-	case logicalplan.BinaryExpr:
+	case *logicalplan.BinaryExpr:
 		return binaryBooleanExpr(e)
 	default:
 		return nil, fmt.Errorf("unsupported boolean expression %T", e)

--- a/query/engine.go
+++ b/query/engine.go
@@ -95,14 +95,7 @@ func (b LocalQueryBuilder) Execute(ctx context.Context, callback func(r arrow.Re
 		return err
 	}
 
-	optimizers := []logicalplan.Optimizer{
-		&logicalplan.PhysicalProjectionPushDown{},
-		&logicalplan.FilterPushDown{},
-		&logicalplan.DistinctPushDown{},
-		&logicalplan.ProjectionPushDown{},
-	}
-
-	for _, optimizer := range optimizers {
+	for _, optimizer := range logicalplan.DefaultOptimizers {
 		logicalPlan = optimizer.Optimize(logicalPlan)
 	}
 

--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -62,16 +62,25 @@ type StaticColumnMatcher struct {
 	ColumnName string
 }
 
+func (m StaticColumnMatcher) Name() string {
+	return m.ColumnName
+}
+
 func (m StaticColumnMatcher) Match(columnName string) bool {
 	return m.ColumnName == columnName
 }
 
 type ColumnMatcher interface {
 	Match(columnName string) bool
+	Name() string
 }
 
 type DynamicColumnMatcher struct {
 	ColumnName string
+}
+
+func (m DynamicColumnMatcher) Name() string {
+	return m.ColumnName
 }
 
 func (m DynamicColumnMatcher) Match(columnName string) bool {

--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -1,6 +1,7 @@
 package logicalplan
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/apache/arrow/go/v8/arrow"
@@ -101,6 +102,11 @@ type Expr interface {
 	// used to identify the column in the resulting Apache Arrow frames, while
 	// ColumnsUsed will return `XYZ` to be necessary to be loaded physically.
 	Matcher() ColumnMatcher
+
+	// Expr implements these two interfaces
+	// so that queries can be transported as JSON.
+	json.Marshaler
+	json.Unmarshaler
 }
 
 func (b Builder) Filter(

--- a/query/logicalplan/builder_test.go
+++ b/query/logicalplan/builder_test.go
@@ -1,6 +1,7 @@
 package logicalplan
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/polarsignals/arcticdb/dynparquet"
@@ -26,23 +27,23 @@ func TestLogicalPlanBuilder(t *testing.T) {
 	require.Equal(t, &LogicalPlan{
 		Projection: &Projection{
 			Exprs: []Expr{
-				Column{ColumnName: "stacktrace"},
+				&Column{ColumnName: "stacktrace"},
 			},
 		},
 		Input: &LogicalPlan{
 			Aggregation: &Aggregation{
-				GroupExprs: []Expr{Column{ColumnName: "stacktrace"}},
-				AggExpr: AliasExpr{
-					Expr:  AggregationFunction{Func: SumAggFunc, Expr: Column{ColumnName: "value"}},
+				GroupExprs: []Expr{&Column{ColumnName: "stacktrace"}},
+				AggExpr: &AliasExpr{
+					Expr:  &AggregationFunction{Func: SumAggFunc, Expr: &Column{ColumnName: "value"}},
 					Alias: "value_sum",
 				},
 			},
 			Input: &LogicalPlan{
 				Filter: &Filter{
-					Expr: BinaryExpr{
-						Left:  Column{ColumnName: "labels.test"},
+					Expr: &BinaryExpr{
+						Left:  &Column{ColumnName: "labels.test"},
 						Op:    EqOp,
-						Right: LiteralExpr{Value: scalar.MakeScalar("abc")},
+						Right: &LiteralExpr{Value: scalar.MakeScalar("abc")},
 					},
 				},
 				Input: &LogicalPlan{
@@ -65,7 +66,7 @@ func TestLogicalPlanBuilderWithoutProjection(t *testing.T) {
 
 	require.Equal(t, &LogicalPlan{
 		Distinct: &Distinct{
-			Columns: []Expr{Column{ColumnName: "labels.test"}},
+			Columns: []Expr{&Column{ColumnName: "labels.test"}},
 		},
 		Input: &LogicalPlan{
 			TableScan: &TableScan{
@@ -74,4 +75,21 @@ func TestLogicalPlanBuilderWithoutProjection(t *testing.T) {
 			},
 		},
 	}, p)
+}
+
+func TestLogicalPlanBuilderFilterJSON(t *testing.T) {
+	p := (&Builder{}).
+		Filter(Col("labels.test").Eq(Literal("abc"))).
+		Filter(Col("name").RegexMatch("^labels$"))
+
+	expected := `{"ExprType":"*logicalplan.BinaryExpr","Expr":{"LeftType":"*logicalplan.Column","Left":{"Expr":"string","ColumnName":"name"},"RightType":"*logicalplan.LiteralExpr","Right":{"ValueType":"*scalar.String","Value":"^labels$"},"Op":6}}`
+
+	output, err := json.Marshal(p.plan.Filter)
+	require.NoError(t, err)
+	require.JSONEq(t, expected, string(output))
+
+	var f *Filter
+	err = json.Unmarshal(output, &f)
+	require.NoError(t, err)
+	require.Equal(t, p.plan.Filter, f)
 }

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -458,43 +458,11 @@ type AggregationFunction struct {
 }
 
 func (f AggregationFunction) MarshalJSON() ([]byte, error) {
-	type aggregationFunctionJSON struct {
-		ExprType string
-		Expr     Expr
-		FuncType string
-		Func     AggFunc
-	}
-	return json.Marshal(aggregationFunctionJSON{
-		ExprType: reflect.TypeOf(f.Expr).String(),
-		Expr:     f.Expr,
-		FuncType: reflect.TypeOf(f.Func).String(),
-		Func:     f.Func,
-	})
+	return nil, fmt.Errorf("AggregationFunction does not implement JSON marshalling")
 }
 
-func (f *AggregationFunction) UnmarshalJSON(data []byte) error {
-	type aggregationFunctionJSON struct {
-		ExprType string
-		Expr     json.RawMessage
-		FuncType string
-		Func     json.RawMessage
-	}
-	var afj aggregationFunctionJSON
-	err := json.Unmarshal(data, &afj)
-	if err != nil {
-		return err
-	}
-	switch afj.ExprType {
-	default:
-		return fmt.Errorf("AggregationFunction.Expr unmarshalling for %s hasn't been implemented", afj.ExprType)
-	}
-
-	switch afj.FuncType {
-	default:
-		return fmt.Errorf("AggregationFunction.Func unmarshalling for %s hasn't been implemented", afj.FuncType)
-	}
-
-	return nil
+func (f *AggregationFunction) UnmarshalJSON([]byte) error {
+	return fmt.Errorf("AggregationFunction does not implement JSON unmarshalling")
 }
 
 func (f AggregationFunction) DataType(s *dynparquet.Schema) (arrow.DataType, error) {
@@ -555,42 +523,11 @@ type AliasExpr struct {
 }
 
 func (e *AliasExpr) MarshalJSON() ([]byte, error) {
-	type aliasExprJSON struct {
-		ExprType string
-		Expr     Expr
-		Alias    string
-	}
-	return json.Marshal(aliasExprJSON{
-		ExprType: reflect.TypeOf(e.Expr).String(),
-		Expr:     e.Expr,
-		Alias:    e.Alias,
-	})
+	return nil, fmt.Errorf("AliasExpr does not implement JSON marshalling")
 }
 
-func (e *AliasExpr) UnmarshalJSON(data []byte) error {
-	type aliasExprJSON struct {
-		ExprType string
-		Expr     json.RawMessage
-		Alias    string
-	}
-	var aej aliasExprJSON
-	err := json.Unmarshal(data, &aej)
-	if err != nil {
-		return err
-	}
-	e.Alias = aej.Alias
-
-	switch aej.ExprType {
-	case "*logicalplan.LiteralExpr":
-		var literal LiteralExpr
-		err := json.Unmarshal(aej.Expr, &literal)
-		if err != nil {
-			return err
-		}
-		e.Expr = &literal
-	}
-
-	return nil
+func (e *AliasExpr) UnmarshalJSON([]byte) error {
+	return fmt.Errorf("AliasExpr does not implement JSON unmarshalling")
 }
 
 func (e AliasExpr) DataType(s *dynparquet.Schema) (arrow.DataType, error) {

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -107,7 +107,7 @@ func (e *BinaryExpr) UnmarshalJSON(data []byte) error {
 		}
 		e.Left = &be
 	default:
-		panic(fmt.Sprintf("BinaryExpr unmarshalling for %s hasn't been implemented", bej.LeftType))
+		return fmt.Errorf("BinaryExpr.Left unmarshalling for %s hasn't been implemented", bej.LeftType)
 	}
 	switch bej.RightType {
 	case "*logicalplan.LiteralExpr":
@@ -125,7 +125,7 @@ func (e *BinaryExpr) UnmarshalJSON(data []byte) error {
 		}
 		e.Right = &be
 	default:
-		panic(fmt.Sprintf("BinaryExpr unmarshalling for %s hasn't been implemented", bej.RightType))
+		return fmt.Errorf("BinaryExpr.Right unmarshalling for %s hasn't been implemented", bej.LeftType)
 	}
 	return nil
 }
@@ -486,12 +486,12 @@ func (f *AggregationFunction) UnmarshalJSON(data []byte) error {
 	}
 	switch afj.ExprType {
 	default:
-		panic(fmt.Sprintf("implement Unmarshalling for %v", afj.ExprType))
+		return fmt.Errorf("AggregationFunction.Expr unmarshalling for %s hasn't been implemented", afj.ExprType)
 	}
 
 	switch afj.FuncType {
 	default:
-		panic(fmt.Sprintf("implement Unmarshalling for %v", afj.FuncType))
+		return fmt.Errorf("AggregationFunction.Func unmarshalling for %s hasn't been implemented", afj.FuncType)
 	}
 
 	return nil

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -159,7 +159,7 @@ type Column struct {
 	ColumnName string
 }
 
-func (c Column) MarshalJSON() ([]byte, error) {
+func (c *Column) MarshalJSON() ([]byte, error) {
 	type columnJSON struct {
 		Expr       string
 		ColumnName string
@@ -184,20 +184,20 @@ func (c *Column) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (c Column) Accept(visitor Visitor) bool {
-	continu := visitor.PreVisit(&c)
+func (c *Column) Accept(visitor Visitor) bool {
+	continu := visitor.PreVisit(c)
 	if !continu {
 		return false
 	}
 
-	return visitor.PostVisit(&c)
+	return visitor.PostVisit(c)
 }
 
-func (c Column) Name() string {
+func (c *Column) Name() string {
 	return c.ColumnName
 }
 
-func (c Column) DataType(s *dynparquet.Schema) (arrow.DataType, error) {
+func (c *Column) DataType(s *dynparquet.Schema) (arrow.DataType, error) {
 	colDef, found := s.ColumnByName(c.ColumnName)
 	if !found {
 		return nil, errors.New("column not found")
@@ -206,77 +206,77 @@ func (c Column) DataType(s *dynparquet.Schema) (arrow.DataType, error) {
 	return convert.ParquetNodeToType(colDef.StorageLayout)
 }
 
-func (c Column) Alias(alias string) AliasExpr {
-	return AliasExpr{Expr: &c, Alias: alias}
+func (c *Column) Alias(alias string) AliasExpr {
+	return AliasExpr{Expr: c, Alias: alias}
 }
 
-func (c Column) ColumnsUsed() []ColumnMatcher {
+func (c *Column) ColumnsUsed() []ColumnMatcher {
 	return []ColumnMatcher{c.Matcher()}
 }
 
-func (c Column) Matcher() ColumnMatcher {
+func (c *Column) Matcher() ColumnMatcher {
 	return StaticColumnMatcher{ColumnName: c.ColumnName}
 }
 
-func (c Column) Eq(e Expr) *BinaryExpr {
+func (c *Column) Eq(e Expr) *BinaryExpr {
 	return &BinaryExpr{
-		Left:  &c,
+		Left:  c,
 		Op:    EqOp,
 		Right: e,
 	}
 }
 
-func (c Column) NotEq(e Expr) BinaryExpr {
-	return BinaryExpr{
-		Left:  &c,
+func (c *Column) NotEq(e Expr) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
 		Op:    NotEqOp,
 		Right: e,
 	}
 }
 
-func (c Column) GT(e Expr) BinaryExpr {
-	return BinaryExpr{
-		Left:  &c,
+func (c *Column) GT(e Expr) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
 		Op:    GTOp,
 		Right: e,
 	}
 }
 
-func (c Column) GTE(e Expr) BinaryExpr {
-	return BinaryExpr{
-		Left:  &c,
+func (c *Column) GTE(e Expr) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
 		Op:    GTEOp,
 		Right: e,
 	}
 }
 
-func (c Column) LT(e Expr) BinaryExpr {
-	return BinaryExpr{
-		Left:  &c,
+func (c *Column) LT(e Expr) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
 		Op:    LTOp,
 		Right: e,
 	}
 }
 
-func (c Column) LTE(e Expr) BinaryExpr {
-	return BinaryExpr{
-		Left:  &c,
+func (c *Column) LTE(e Expr) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
 		Op:    LTEOp,
 		Right: e,
 	}
 }
 
-func (c Column) RegexMatch(pattern string) *BinaryExpr {
+func (c *Column) RegexMatch(pattern string) *BinaryExpr {
 	return &BinaryExpr{
-		Left:  &c,
+		Left:  c,
 		Op:    RegExpOp,
 		Right: Literal(pattern),
 	}
 }
 
-func (c Column) RegexNotMatch(pattern string) BinaryExpr {
-	return BinaryExpr{
-		Left:  &c,
+func (c *Column) RegexNotMatch(pattern string) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
 		Op:    NotRegExpOp,
 		Right: Literal(pattern),
 	}

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -528,8 +528,8 @@ func (f AggFunc) String() string {
 	}
 }
 
-func Sum(expr Expr) AggregationFunction {
-	return AggregationFunction{
+func Sum(expr Expr) *AggregationFunction {
+	return &AggregationFunction{
 		Func: SumAggFunc,
 		Expr: expr,
 	}

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -99,8 +99,15 @@ func (e *BinaryExpr) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		e.Left = &c
+	case "*logicalplan.BinaryExpr":
+		var be BinaryExpr
+		err := json.Unmarshal(bej.Left, &be)
+		if err != nil {
+			return err
+		}
+		e.Left = &be
 	default:
-		panic("unmarshalling for expr hasn't been implemented")
+		panic(fmt.Sprintf("BinaryExpr unmarshalling for %s hasn't been implemented", bej.LeftType))
 	}
 	switch bej.RightType {
 	case "*logicalplan.LiteralExpr":
@@ -110,8 +117,15 @@ func (e *BinaryExpr) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		e.Right = &literal
+	case "*logicalplan.BinaryExpr":
+		var be BinaryExpr
+		err := json.Unmarshal(bej.Right, &be)
+		if err != nil {
+			return err
+		}
+		e.Right = &be
 	default:
-		panic("unmarshalling for expr hasn't been implemented")
+		panic(fmt.Sprintf("BinaryExpr unmarshalling for %s hasn't been implemented", bej.RightType))
 	}
 	return nil
 }

--- a/query/logicalplan/optimize.go
+++ b/query/logicalplan/optimize.go
@@ -4,6 +4,13 @@ type Optimizer interface {
 	Optimize(plan *LogicalPlan) *LogicalPlan
 }
 
+var DefaultOptimizers = []Optimizer{
+	&PhysicalProjectionPushDown{},
+	&FilterPushDown{},
+	&DistinctPushDown{},
+	&ProjectionPushDown{},
+}
+
 // The PhysicalProjectionPushDown optimizer tries to push down the actual
 // physical columns used by the query to the table scan, so the table provider
 // can decide to only read the columns that are actually going to be used by

--- a/query/logicalplan/optimize_test.go
+++ b/query/logicalplan/optimize_test.go
@@ -82,10 +82,10 @@ func TestOptimizeFilterPushDown(t *testing.T) {
 		TableName:     "table1",
 		TableProvider: tableProvider,
 		// Only these columns are needed to compute the result.
-		Filter: BinaryExpr{
-			Left: Column{ColumnName: "labels.test"},
+		Filter: &BinaryExpr{
+			Left: &Column{ColumnName: "labels.test"},
 			Op:   EqOp,
-			Right: LiteralExpr{
+			Right: &LiteralExpr{
 				Value: scalar.MakeScalar("abc"),
 			},
 		},
@@ -206,10 +206,10 @@ func TestAllOptimizers(t *testing.T) {
 			StaticColumnMatcher{ColumnName: "value"},
 			StaticColumnMatcher{ColumnName: "labels.test"},
 		},
-		Filter: BinaryExpr{
-			Left: Column{ColumnName: "labels.test"},
+		Filter: &BinaryExpr{
+			Left: &Column{ColumnName: "labels.test"},
 			Op:   EqOp,
-			Right: LiteralExpr{
+			Right: &LiteralExpr{
 				Value: scalar.MakeScalar("abc"),
 			},
 		},

--- a/query/logicalplan/validate.go
+++ b/query/logicalplan/validate.go
@@ -175,8 +175,8 @@ func ValidateFilter(plan *LogicalPlan) *PlanValidationError {
 // ValidateFilterExpr validates filter's expression.
 func ValidateFilterExpr(plan *LogicalPlan, e Expr) *ExprValidationError {
 	switch expr := e.(type) {
-	case BinaryExpr:
-		err := ValidateFilterBinaryExpr(plan, &expr)
+	case *BinaryExpr:
+		err := ValidateFilterBinaryExpr(plan, expr)
 		return err
 	}
 
@@ -200,7 +200,7 @@ func ValidateFilterBinaryExpr(plan *LogicalPlan, expr *BinaryExpr) *ExprValidati
 	}
 
 	// try to find the column in the schema
-	columnExpr := leftColumnFinder.result.(Column)
+	columnExpr := leftColumnFinder.result.(*Column)
 	schema := plan.InputSchema()
 	if schema != nil {
 		column, found := schema.ColumnByName(columnExpr.ColumnName)
@@ -211,7 +211,7 @@ func ValidateFilterBinaryExpr(plan *LogicalPlan, expr *BinaryExpr) *ExprValidati
 			if rightLiteralFinder.result != nil {
 				// ensure that the column type is compatible with the literal being compared to it
 				t := column.StorageLayout.Type()
-				literalExpr := rightLiteralFinder.result.(LiteralExpr)
+				literalExpr := rightLiteralFinder.result.(*LiteralExpr)
 				if err := ValidateComparingTypes(t.LogicalType(), literalExpr.Value); err != nil {
 					err.expr = expr
 					return err
@@ -293,7 +293,7 @@ func newTypeFinder(val interface{}) findExpressionForTypeVisitor {
 type findExpressionForTypeVisitor struct {
 	exprType reflect.Type
 	// if an expression of the type is found, it will be set on this field after
-	// visiting. Other-wise this field will be null
+	// visiting. Other-wise this field will be nil
 	result Expr
 }
 

--- a/query/logicalplan/validate.go
+++ b/query/logicalplan/validate.go
@@ -285,7 +285,7 @@ func ValidateFilterAndBinaryExpr(plan *LogicalPlan, expr *BinaryExpr) *ExprValid
 // NewTypeFinder returns an instance of the findExpressionForTypeVisitor for the
 // passed type. It expects to receive a pointer to the  type it is will find.
 func newTypeFinder(val interface{}) findExpressionForTypeVisitor {
-	return findExpressionForTypeVisitor{exprType: reflect.TypeOf(val).Elem()}
+	return findExpressionForTypeVisitor{exprType: reflect.TypeOf(val)}
 }
 
 // findExpressionForTypeVisitor is an instance of Visitor that will try to find

--- a/query/logicalplan/validate_test.go
+++ b/query/logicalplan/validate_test.go
@@ -12,7 +12,7 @@ import (
 func TestOnlyOneFieldCanBeSet(t *testing.T) {
 	plan := LogicalPlan{
 		Filter: &Filter{
-			Expr: BinaryExpr{
+			Expr: &BinaryExpr{
 				Left:  Col("example_type"),
 				Op:    EqOp,
 				Right: Literal(4),
@@ -35,12 +35,12 @@ func TestOnlyOneFieldCanBeSet(t *testing.T) {
 func TestCanTraverseInputThatIsInvalid(t *testing.T) {
 	_, err := (&Builder{}).
 		Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
-		Filter(BinaryExpr{
+		Filter(&BinaryExpr{
 			Left:  Col("example_type"),
 			Op:    EqOp,
 			Right: Literal(4),
 		}).
-		Filter(BinaryExpr{
+		Filter(&BinaryExpr{
 			Left:  Col("stacktrace"),
 			Op:    EqOp,
 			Right: Literal(4),
@@ -60,7 +60,7 @@ func TestCanTraverseInputThatIsInvalid(t *testing.T) {
 func TestFilterBinaryExprLeftSideMustBeColumn(t *testing.T) {
 	_, err := (&Builder{}).
 		Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
-		Filter(BinaryExpr{
+		Filter(&BinaryExpr{
 			Left:  Literal(5),
 			Op:    EqOp,
 			Right: Literal(4),
@@ -78,7 +78,7 @@ func TestFilterBinaryExprLeftSideMustBeColumn(t *testing.T) {
 func TestFilterBinaryExprColMustMatchLiteralType(t *testing.T) {
 	_, err := (&Builder{}).
 		Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
-		Filter(BinaryExpr{
+		Filter(&BinaryExpr{
 			Left:  Col("example_type"),
 			Op:    EqOp,
 			Right: Literal(4.6),
@@ -96,7 +96,7 @@ func TestFilterBinaryExprColMustMatchLiteralType(t *testing.T) {
 	// check that it also works the other way around, can't compare number w/ string
 	_, err = (&Builder{}).
 		Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
-		Filter(BinaryExpr{
+		Filter(&BinaryExpr{
 			Left:  Col("timestamp"),
 			Op:    EqOp,
 			Right: Literal("albert"),
@@ -115,12 +115,12 @@ func TestFilterAndExprEvaluatesEachAndedRule(t *testing.T) {
 	_, err := (&Builder{}).
 		Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
 		Filter(And(
-			BinaryExpr{
+			&BinaryExpr{
 				Left:  Col("example_type"),
 				Op:    EqOp,
 				Right: Literal(4),
 			},
-			BinaryExpr{
+			&BinaryExpr{
 				Left:  Literal("a"),
 				Op:    EqOp,
 				Right: Literal("b"),

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -36,10 +36,10 @@ func Aggregate(
 
 	agg.AggExpr.Accept(PreExprVisitorFunc(func(expr logicalplan.Expr) bool {
 		switch e := expr.(type) {
-		case logicalplan.AggregationFunction:
+		case *logicalplan.AggregationFunction:
 			aggFunc = e.Func
 			aggFuncFound = true
-		case logicalplan.Column:
+		case *logicalplan.Column:
 			aggColumnMatcher = e.Matcher()
 			aggColumnFound = true
 		}

--- a/query/physicalplan/distinct.go
+++ b/query/physicalplan/distinct.go
@@ -86,6 +86,7 @@ func (d *Distinction) Callback(r arrow.Record) error {
 			d.mtx.RUnlock()
 			continue
 		}
+		d.mtx.RUnlock()
 
 		for j, arr := range distinctArrays {
 			err := appendValue(resBuilders[j], arr, i)

--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -44,13 +44,13 @@ func (f PreExprVisitorFunc) PostVisit(expr logicalplan.Expr) bool {
 	return false
 }
 
-func binaryBooleanExpr(expr logicalplan.BinaryExpr) (BooleanExpression, error) {
+func binaryBooleanExpr(expr *logicalplan.BinaryExpr) (BooleanExpression, error) {
 	switch expr.Op {
 	case logicalplan.EqOp, logicalplan.NotEqOp, logicalplan.LTOp, logicalplan.LTEOp, logicalplan.GTOp, logicalplan.GTEOp, logicalplan.RegExpOp, logicalplan.NotRegExpOp:
 		var leftColumnRef *ArrayRef
 		expr.Left.Accept(PreExprVisitorFunc(func(expr logicalplan.Expr) bool {
 			switch e := expr.(type) {
-			case logicalplan.Column:
+			case *logicalplan.Column:
 				leftColumnRef = &ArrayRef{
 					ColumnName: e.ColumnName,
 				}
@@ -65,7 +65,7 @@ func binaryBooleanExpr(expr logicalplan.BinaryExpr) (BooleanExpression, error) {
 		var rightScalar scalar.Scalar
 		expr.Right.Accept(PreExprVisitorFunc(func(expr logicalplan.Expr) bool {
 			switch e := expr.(type) {
-			case logicalplan.LiteralExpr:
+			case *logicalplan.LiteralExpr:
 				rightScalar = e.Value
 				return false
 			}
@@ -146,7 +146,7 @@ func (a *AndExpr) String() string {
 
 func booleanExpr(expr logicalplan.Expr) (BooleanExpression, error) {
 	switch e := expr.(type) {
-	case logicalplan.BinaryExpr:
+	case *logicalplan.BinaryExpr:
 		return binaryBooleanExpr(e)
 	default:
 		return nil, ErrUnsupportedBooleanExpression

--- a/query/physicalplan/project.go
+++ b/query/physicalplan/project.go
@@ -73,16 +73,16 @@ func (p plainProjection) Project(mem memory.Allocator, ar arrow.Record) (arrow.F
 
 func projectionFromExpr(expr logicalplan.Expr) (columnProjection, error) {
 	switch e := expr.(type) {
-	case logicalplan.Column:
+	case *logicalplan.Column:
 		return plainProjection{
 			matcher: e.Matcher(),
 		}, nil
-	case logicalplan.AliasExpr:
+	case *logicalplan.AliasExpr:
 		return aliasProjection{
 			matcher: e.Matcher(),
 			name:    e.Name(),
 		}, nil
-	case logicalplan.BinaryExpr:
+	case *logicalplan.BinaryExpr:
 		boolExpr, err := binaryBooleanExpr(e)
 		if err != nil {
 			return nil, err

--- a/table.go
+++ b/table.go
@@ -991,21 +991,21 @@ func filterGranule(logger log.Logger, filterExpr logicalplan.Expr, g *Granule) b
 	default: // unsupported filter
 		level.Info(logger).Log("msg", "unsupported filter")
 		return true
-	case logicalplan.BinaryExpr:
+	case *logicalplan.BinaryExpr:
 		var min, max *parquet.Value
 		var v scalar.Scalar
 		var leftresult bool
 		switch left := expr.Left.(type) {
-		case logicalplan.BinaryExpr:
+		case *logicalplan.BinaryExpr:
 			leftresult = filterGranule(logger, left, g)
-		case logicalplan.Column:
+		case *logicalplan.Column:
 			var found bool
 			min, max, found = findColumnValues(left.ColumnsUsed(), g)
 			if !found {
 				// If we fallthrough to here, than we didn't find any columns that match so we can skip this granule
 				return false
 			}
-		case logicalplan.LiteralExpr:
+		case *logicalplan.LiteralExpr:
 			switch left.Value.(type) {
 			case *scalar.Int64:
 				v = left.Value.(*scalar.Int64)
@@ -1015,7 +1015,7 @@ func filterGranule(logger log.Logger, filterExpr logicalplan.Expr, g *Granule) b
 		}
 
 		switch right := expr.Right.(type) {
-		case logicalplan.BinaryExpr:
+		case *logicalplan.BinaryExpr:
 			switch expr.Op {
 			case logicalplan.AndOp:
 				if !leftresult {
@@ -1024,7 +1024,7 @@ func filterGranule(logger log.Logger, filterExpr logicalplan.Expr, g *Granule) b
 				rightresult := filterGranule(logger, right, g)
 				return leftresult && rightresult
 			}
-		case logicalplan.Column:
+		case *logicalplan.Column:
 			var found bool
 			min, max, found = findColumnValues(right.ColumnsUsed(), g)
 			if !found {
@@ -1057,7 +1057,7 @@ func filterGranule(logger log.Logger, filterExpr logicalplan.Expr, g *Granule) b
 				}
 			}
 
-		case logicalplan.LiteralExpr:
+		case *logicalplan.LiteralExpr:
 			switch v := right.Value.(type) {
 			case *scalar.Int64:
 				switch expr.Op {

--- a/table_test.go
+++ b/table_test.go
@@ -282,7 +282,7 @@ func Test_Table_GranuleSplit(t *testing.T) {
 	}
 	table.Iterator(context.Background(), memory.NewGoAllocator(), nil, nil, nil, func(r arrow.Record) error {
 		defer r.Release()
-		// t.Log(r)
+		t.Log(r)
 		return nil
 	})
 
@@ -422,7 +422,7 @@ func Test_Table_InsertLowest(t *testing.T) {
 
 	table.Iterator(context.Background(), memory.NewGoAllocator(), nil, nil, nil, func(r arrow.Record) error {
 		defer r.Release()
-		// t.Log(r)
+		t.Log(r)
 		return nil
 	})
 

--- a/table_test.go
+++ b/table_test.go
@@ -282,7 +282,7 @@ func Test_Table_GranuleSplit(t *testing.T) {
 	}
 	table.Iterator(context.Background(), memory.NewGoAllocator(), nil, nil, nil, func(r arrow.Record) error {
 		defer r.Release()
-		t.Log(r)
+		// t.Log(r)
 		return nil
 	})
 
@@ -422,7 +422,7 @@ func Test_Table_InsertLowest(t *testing.T) {
 
 	table.Iterator(context.Background(), memory.NewGoAllocator(), nil, nil, nil, func(r arrow.Record) error {
 		defer r.Release()
-		t.Log(r)
+		// t.Log(r)
 		return nil
 	})
 


### PR DESCRIPTION
Most importantly the `type Expr interface` now adds `json.Marshaler` & `json.Unmarshaler`.
For that, to work the structs implementing the `Expr` interface are now pointers.

A slight other improvement is the addition `DefaultOptimizers` wrapper, so it's easier to use in Parca and others.

In the future, it might be nice to use protobuf for sending the filters, but so far JSON was totally fine.