### PR TITLE
Fix race cond

### DIFF
--- a/table_test.go
+++ b/table_test.go
@@ -264,11 +264,11 @@ func Test_Table_GranuleSplit(t *testing.T) {
 	buf, err = samples.ToBuffer(table.Schema())
 	require.NoError(t, err)
 
-	tx, err := table.InsertBuffer(context.Background(), buf)
-	require.NoError(t, err)
-
 	// Wait for the index to be updated by the asynchronous granule split.
 	table.Sync()
+
+	tx, err := table.InsertBuffer(context.Background(), buf)
+	require.NoError(t, err)
 
 	// Wait for the last tx to be marked as completed
 	table.db.Wait(tx)


### PR DESCRIPTION
This fixes the error with the `GranuleSplit` unit test reported in #71 
It was a matter of a non-deterministic split that was happening. If we just wait for the split before the final write we test the logic we're looking for. 