### PR TITLE
Fix for concurrency race

### DIFF
--- a/table.go
+++ b/table.go
@@ -725,13 +725,6 @@ func (t *TableBlock) Index() *btree.BTree {
 	return (*btree.BTree)(t.index.Load())
 }
 
-func (t *TableBlock) granuleIterator(iterator func(g *Granule) bool) {
-	t.Index().Ascend(func(i btree.Item) bool {
-		g := i.(*Granule)
-		return iterator(g)
-	})
-}
-
 func (t *TableBlock) splitRowsByGranule(buf *dynparquet.SerializedBuffer) (map[*Granule]*dynparquet.SerializedBuffer, error) {
 	// Special case: if there is only one granule, insert parts into it until full.
 	index := t.Index()


### PR DESCRIPTION
If we start a new transaction, reads that started after the last
committed write, but before the compaction wont be able to find those commited
reads. Instead copy the watermark as the tx id to allow those reads to
be able to read all the committed data.

This is should be the fix for #71 