### PR TITLE
Fix index concurrency problem

### DIFF
--- a/table.go
+++ b/table.go
@@ -664,7 +664,7 @@ func (t *TableBlock) splitGranule(granule *Granule) {
 		}
 
 		// Point to the new index
-		if t.index.CAS(t.index.Load(), unsafe.Pointer(index)) {
+		if t.index.CAS(unsafe.Pointer(curIndex), unsafe.Pointer(index)) {
 			sizeDiff := serBuf.ParquetFile().Size() - sizeBefore
 			t.size.Add(sizeDiff)
 			return


### PR DESCRIPTION
Hi, all! I think I found a race condition in the following snippet inside the `splitGranule()` method:
```golang
for {
		curIndex := t.Index()
		t.mtx.Lock()
		index := curIndex.Clone() // TODO(THOR): we can't clone concurrently
		t.mtx.Unlock()

		deleted := index.Delete(granule)
		if deleted == nil {
			level.Error(t.logger).Log("msg", "failed to delete granule during split")
		}

		for _, g := range granules {
			if dupe := index.ReplaceOrInsert(g); dupe != nil {
				level.Error(t.logger).Log("duplicate insert performed")
			}
		}

		// Point to the new index
		if t.index.CAS(t.index.Load(), unsafe.Pointer(index)) {
			sizeDiff := serBuf.ParquetFile().Size() - sizeBefore
			t.size.Add(sizeDiff)
			return
		}
	}
```
In particular, I replaced this check:
```golang
if t.index.CAS(t.index.Load(), unsafe.Pointer(index)) {
```
with the following
```golang
if t.index.CAS(unsafe.Pointer(curIndex), unsafe.Pointer(index)) {
```
The first statement only detect concurrent changes happening between the `t.index.Load()` statement and the `t.index.CAS()` statement.
However, a goroutine may finish the execution of the statement 

```golang
if t.index.CAS(t.index.Load(), unsafe.Pointer(index)) {
```
before another goroutine start executing the `t.index.Load()`.

I think this can be related with the problem detailed in #84 