### PR TITLE
TableReader returns ArrowSchema for request

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -43,6 +43,8 @@ func arrowScalarToParquetValue(sc scalar.Scalar) (parquet.Value, error) {
 		v := [16]byte{}
 		copy(v[:width], s.Data())
 		return parquet.ValueOf(v), nil
+	case nil:
+		return parquet.Value{}, nil
 	default:
 		return parquet.Value{}, fmt.Errorf("unsupported scalar type %T", s)
 	}

--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -25,7 +25,7 @@ func ParquetRowGroupToArrowRecord(
 	projections []logicalplan.ColumnMatcher,
 	filterExpr logicalplan.Expr,
 	distinctColumns []logicalplan.ColumnMatcher,
-) (arrow.Record, error) {
+) (arrow.Record, *arrow.Schema, error) {
 	switch rg.(type) {
 	case *dynparquet.MergedRowGroup:
 		return rowBasedParquetRowGroupToArrowRecord(ctx, pool, rg)
@@ -46,7 +46,7 @@ func rowBasedParquetRowGroupToArrowRecord(
 	ctx context.Context,
 	pool memory.Allocator,
 	rg parquet.RowGroup,
-) (arrow.Record, error) {
+) (arrow.Record, *arrow.Schema, error) {
 	s := rg.Schema()
 
 	parquetFields := s.Fields()
@@ -55,13 +55,13 @@ func rowBasedParquetRowGroupToArrowRecord(
 	for _, parquetField := range parquetFields {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		default:
 			name := parquetField.Name()
 			node := dynparquet.FieldByName(s, name)
 			typ, newValueWriter, err := convert.ParquetNodeToTypeWithWriterFunc(node)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			nullable := false
 			if node.Optional() {
@@ -93,7 +93,7 @@ func rowBasedParquetRowGroupToArrowRecord(
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		default:
 		}
 		rowBuf := make([]parquet.Row, 64) // Random guess.
@@ -102,7 +102,7 @@ func rowBasedParquetRowGroupToArrowRecord(
 			break
 		}
 		if err != nil && err != io.EOF {
-			return nil, fmt.Errorf("read row: %w", err)
+			return nil, nil, fmt.Errorf("read row: %w", err)
 		}
 		rowBuf = rowBuf[:n]
 
@@ -117,7 +117,7 @@ func rowBasedParquetRowGroupToArrowRecord(
 		}
 	}
 
-	return b.NewRecord(), nil
+	return b.NewRecord(), b.Schema(), nil
 }
 
 // contiguousParquetRowGroupToArrowRecord converts a parquet row group to an arrow record.
@@ -128,7 +128,7 @@ func contiguousParquetRowGroupToArrowRecord(
 	projections []logicalplan.ColumnMatcher,
 	filterExpr logicalplan.Expr,
 	distinctColumns []logicalplan.ColumnMatcher,
-) (arrow.Record, error) {
+) (arrow.Record, *arrow.Schema, error) {
 	s := rg.Schema()
 	parquetColumns := rg.ColumnChunks()
 	parquetFields := s.Fields()
@@ -142,7 +142,7 @@ func contiguousParquetRowGroupToArrowRecord(
 		for i, field := range parquetFields {
 			select {
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return nil, nil, ctx.Err()
 			default:
 				name := field.Name()
 				if distinctColumns[0].Match(name) {
@@ -153,7 +153,7 @@ func contiguousParquetRowGroupToArrowRecord(
 						true,
 					)
 					if err != nil {
-						return nil, fmt.Errorf("convert parquet column to arrow array: %w", err)
+						return nil, nil, fmt.Errorf("convert parquet column to arrow array: %w", err)
 					}
 					fields = append(fields, arrow.Field{
 						Name:     name,
@@ -167,7 +167,7 @@ func contiguousParquetRowGroupToArrowRecord(
 		}
 
 		schema := arrow.NewSchema(fields, nil)
-		return array.NewRecord(schema, cols, rows), nil
+		return array.NewRecord(schema, cols, rows), schema, nil
 	}
 
 	fields := make([]arrow.Field, 0, len(parquetFields))
@@ -176,7 +176,7 @@ func contiguousParquetRowGroupToArrowRecord(
 	for i, parquetField := range parquetFields {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		default:
 			if includedProjection(projections, parquetField.Name()) {
 				typ, nullable, array, err := parquetColumnToArrowArray(
@@ -186,7 +186,7 @@ func contiguousParquetRowGroupToArrowRecord(
 					false,
 				)
 				if err != nil {
-					return nil, fmt.Errorf("convert parquet column to arrow array: %w", err)
+					return nil, nil, fmt.Errorf("convert parquet column to arrow array: %w", err)
 				}
 				fields = append(fields, arrow.Field{
 					Name:     parquetField.Name(),
@@ -199,7 +199,7 @@ func contiguousParquetRowGroupToArrowRecord(
 	}
 
 	schema := arrow.NewSchema(fields, nil)
-	return array.NewRecord(schema, cols, rg.NumRows()), nil
+	return array.NewRecord(schema, cols, rg.NumRows()), schema, nil
 }
 
 func includedProjection(projections []logicalplan.ColumnMatcher, name string) bool {

--- a/pqarrow/arrow_test.go
+++ b/pqarrow/arrow_test.go
@@ -90,10 +90,11 @@ func TestMergeToArrow(t *testing.T) {
 	merge, err := schema.MergeDynamicRowGroups([]dynparquet.DynamicRowGroup{buf1, buf2, buf3})
 	require.NoError(t, err)
 
-	ar, err := ParquetRowGroupToArrowRecord(context.Background(), memory.DefaultAllocator, merge, nil, nil, nil)
+	ar, as, err := ParquetRowGroupToArrowRecord(context.Background(), memory.DefaultAllocator, merge, nil, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(5), ar.NumRows())
 	require.Equal(t, int64(8), ar.NumCols())
+	require.Len(t, as.Fields(), 8)
 }
 
 func BenchmarkParquetToArrow(b *testing.B) {
@@ -121,7 +122,7 @@ func BenchmarkParquetToArrow(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err = ParquetRowGroupToArrowRecord(context.Background(), memory.DefaultAllocator, buf, nil, nil, nil)
+		_, _, err = ParquetRowGroupToArrowRecord(context.Background(), memory.DefaultAllocator, buf, nil, nil, nil)
 		require.NoError(b, err)
 	}
 }

--- a/pqarrow/arrow_test.go
+++ b/pqarrow/arrow_test.go
@@ -90,11 +90,11 @@ func TestMergeToArrow(t *testing.T) {
 	merge, err := schema.MergeDynamicRowGroups([]dynparquet.DynamicRowGroup{buf1, buf2, buf3})
 	require.NoError(t, err)
 
-	ar, as, err := ParquetRowGroupToArrowRecord(context.Background(), memory.DefaultAllocator, merge, nil, nil, nil)
+	ar, err := ParquetRowGroupToArrowRecord(context.Background(), memory.DefaultAllocator, merge, nil, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(5), ar.NumRows())
 	require.Equal(t, int64(8), ar.NumCols())
-	require.Len(t, as.Fields(), 8)
+	require.Len(t, ar.Schema().Fields(), 8)
 }
 
 func BenchmarkParquetToArrow(b *testing.B) {
@@ -122,7 +122,7 @@ func BenchmarkParquetToArrow(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _, err = ParquetRowGroupToArrowRecord(context.Background(), memory.DefaultAllocator, buf, nil, nil, nil)
+		_, err = ParquetRowGroupToArrowRecord(context.Background(), memory.DefaultAllocator, buf, nil, nil, nil)
 		require.NoError(b, err)
 	}
 }

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -118,6 +118,13 @@ type TableReader interface {
 		distinctColumns []ColumnMatcher,
 		callback func(r arrow.Record) error,
 	) error
+	ArrowSchema(
+		ctx context.Context,
+		pool memory.Allocator,
+		projection []ColumnMatcher,
+		filter Expr, // TODO: We probably don't need this
+		distinctColumns []ColumnMatcher,
+	) (*arrow.Schema, error)
 	Schema() *dynparquet.Schema
 }
 

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -102,8 +102,10 @@ func (plan *LogicalPlan) Accept(visitor PlanVisitor) bool {
 }
 
 type TableReader interface {
+	View(func(tx uint64) error) error
 	Iterator(
 		ctx context.Context,
+		tx uint64,
 		pool memory.Allocator,
 		projection []ColumnMatcher,
 		filter Expr,
@@ -112,6 +114,7 @@ type TableReader interface {
 	) error
 	SchemaIterator(
 		ctx context.Context,
+		tx uint64,
 		pool memory.Allocator,
 		projection []ColumnMatcher,
 		filter Expr,
@@ -120,6 +123,7 @@ type TableReader interface {
 	) error
 	ArrowSchema(
 		ctx context.Context,
+		tx uint64,
 		pool memory.Allocator,
 		projection []ColumnMatcher,
 		filter Expr, // TODO: We probably don't need this

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -41,6 +41,16 @@ func (m *mockTableReader) SchemaIterator(
 	return nil
 }
 
+func (m *mockTableReader) ArrowSchema(
+	ctx context.Context,
+	pool memory.Allocator,
+	projection []ColumnMatcher,
+	filter Expr,
+	distinctColumns []ColumnMatcher,
+) (*arrow.Schema, error) {
+	return nil, nil
+}
+
 type mockTableProvider struct {
 	schema *dynparquet.Schema
 }

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -19,8 +19,13 @@ func (m *mockTableReader) Schema() *dynparquet.Schema {
 	return m.schema
 }
 
+func (m *mockTableReader) View(fn func(tx uint64) error) error {
+	return nil
+}
+
 func (m *mockTableReader) Iterator(
 	ctx context.Context,
+	tx uint64,
 	pool memory.Allocator,
 	projection []ColumnMatcher,
 	filter Expr,
@@ -32,6 +37,7 @@ func (m *mockTableReader) Iterator(
 
 func (m *mockTableReader) SchemaIterator(
 	ctx context.Context,
+	tx uint64,
 	pool memory.Allocator,
 	projection []ColumnMatcher,
 	filter Expr,
@@ -43,6 +49,7 @@ func (m *mockTableReader) SchemaIterator(
 
 func (m *mockTableReader) ArrowSchema(
 	ctx context.Context,
+	tx uint64,
 	pool memory.Allocator,
 	projection []ColumnMatcher,
 	filter Expr,

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -69,14 +69,17 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 	if table == nil {
 		return errors.New("table not found")
 	}
-	err := table.Iterator(
-		ctx,
-		pool,
-		s.options.Projection,
-		s.options.Filter,
-		s.options.Distinct,
-		s.next.Callback,
-	)
+	err := table.View(func(tx uint64) error {
+		return table.Iterator(
+			ctx,
+			tx,
+			pool,
+			s.options.Projection,
+			s.options.Filter,
+			s.options.Distinct,
+			s.next.Callback,
+		)
+	})
 	if err != nil {
 		return err
 	}
@@ -95,14 +98,17 @@ func (s *SchemaScan) Execute(ctx context.Context, pool memory.Allocator) error {
 	if table == nil {
 		return errors.New("table not found")
 	}
-	err := table.SchemaIterator(
-		ctx,
-		pool,
-		s.options.Projection,
-		s.options.Filter,
-		s.options.Distinct,
-		s.next.Callback,
-	)
+	err := table.View(func(tx uint64) error {
+		return table.SchemaIterator(
+			ctx,
+			tx,
+			pool,
+			s.options.Projection,
+			s.options.Filter,
+			s.options.Distinct,
+			s.next.Callback,
+		)
+	})
 	if err != nil {
 		return err
 	}

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -43,6 +43,16 @@ func (m *mockTableReader) SchemaIterator(
 	return nil
 }
 
+func (m *mockTableReader) ArrowSchema(
+	ctx context.Context,
+	pool memory.Allocator,
+	projection []logicalplan.ColumnMatcher,
+	filter logicalplan.Expr,
+	distinctColumns []logicalplan.ColumnMatcher,
+) (*arrow.Schema, error) {
+	return nil, nil
+}
+
 type mockTableProvider struct {
 	schema *dynparquet.Schema
 }

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -21,8 +21,13 @@ func (m *mockTableReader) Schema() *dynparquet.Schema {
 	return m.schema
 }
 
+func (m *mockTableReader) View(fn func(tx uint64) error) error {
+	return nil
+}
+
 func (m *mockTableReader) Iterator(
 	ctx context.Context,
+	tx uint64,
 	pool memory.Allocator,
 	projection []logicalplan.ColumnMatcher,
 	filter logicalplan.Expr,
@@ -34,6 +39,7 @@ func (m *mockTableReader) Iterator(
 
 func (m *mockTableReader) SchemaIterator(
 	ctx context.Context,
+	tx uint64,
 	pool memory.Allocator,
 	projection []logicalplan.ColumnMatcher,
 	filter logicalplan.Expr,
@@ -45,6 +51,7 @@ func (m *mockTableReader) SchemaIterator(
 
 func (m *mockTableReader) ArrowSchema(
 	ctx context.Context,
+	tx uint64,
 	pool memory.Allocator,
 	projection []logicalplan.ColumnMatcher,
 	filter logicalplan.Expr,

--- a/table.go
+++ b/table.go
@@ -430,6 +430,9 @@ func (t *Table) ArrowSchema(
 		return nil, err
 	}
 
+	// TODO: We should be able to figure out if dynamic columns are even queried.
+	// If not, then we can simply return the first schema.
+
 	fieldNames := make([]string, 0, 16)
 	fieldsMap := make(map[string]arrow.Field)
 

--- a/table.go
+++ b/table.go
@@ -269,9 +269,14 @@ func (t *Table) Insert(ctx context.Context, buf []byte) (uint64, error) {
 	return tx, nil
 }
 
+func (t *Table) View(fn func(tx uint64) error) error {
+	return fn(t.db.beginRead())
+}
+
 // Iterator iterates in order over all granules in the table. It stops iterating when the iterator function returns false.
 func (t *Table) Iterator(
 	ctx context.Context,
+	tx uint64,
 	pool memory.Allocator,
 	projections []logicalplan.ColumnMatcher,
 	filterExpr logicalplan.Expr,
@@ -307,7 +312,7 @@ func (t *Table) Iterator(
 	t.mtx.RUnlock()
 
 	for _, block := range memoryBlocks {
-		if err := block.RowGroupIterator(ctx, filterExpr, filter, false, iteratorFunc); err != nil {
+		if err := block.RowGroupIterator(ctx, tx, filterExpr, filter, iteratorFunc); err != nil {
 			return err
 		}
 	}
@@ -353,6 +358,7 @@ func (t *Table) Iterator(
 // all the schemas seen across the table.
 func (t *Table) SchemaIterator(
 	ctx context.Context,
+	tx uint64,
 	pool memory.Allocator,
 	projections []logicalplan.ColumnMatcher,
 	filterExpr logicalplan.Expr,
@@ -365,7 +371,7 @@ func (t *Table) SchemaIterator(
 	}
 
 	rowGroups := []dynparquet.DynamicRowGroup{}
-	err = t.ActiveBlock().RowGroupIterator(ctx, nil, filter, false, func(rg dynparquet.DynamicRowGroup) bool {
+	err = t.ActiveBlock().RowGroupIterator(ctx, tx, nil, filter, func(rg dynparquet.DynamicRowGroup) bool {
 		rowGroups = append(rowGroups, rg)
 		return true
 	})
@@ -409,6 +415,7 @@ func (t *Table) SchemaIterator(
 
 func (t *Table) ArrowSchema(
 	ctx context.Context,
+	tx uint64,
 	pool memory.Allocator,
 	projections []logicalplan.ColumnMatcher,
 	filterExpr logicalplan.Expr,
@@ -420,7 +427,7 @@ func (t *Table) ArrowSchema(
 	}
 
 	rowGroups := []dynparquet.DynamicRowGroup{}
-	err = t.ActiveBlock().RowGroupIterator(ctx, nil, filter, false,
+	err = t.ActiveBlock().RowGroupIterator(ctx, tx, nil, filter,
 		func(rg dynparquet.DynamicRowGroup) bool {
 			rowGroups = append(rowGroups, rg)
 			return true
@@ -730,20 +737,16 @@ func (t *TableBlock) splitGranule(granule *Granule) {
 	}
 }
 
-// Iterator iterates in order over all granules in the table. It stops iterating when the iterator function returns false.
+// RowGroupIterator iterates in order over all granules in the table.
+// It stops iterating when the iterator function returns false.
 func (t *TableBlock) RowGroupIterator(
 	ctx context.Context,
+	tx uint64,
 	filterExpr logicalplan.Expr,
 	filter TrueNegativeFilter,
-	ignoreWatermark bool,
 	iterator func(rg dynparquet.DynamicRowGroup) bool,
 ) error {
 	index := t.Index()
-
-	watermark := uint64(math.MaxUint64)
-	if !ignoreWatermark {
-		watermark = t.table.db.beginRead()
-	}
 
 	var err error
 	index.Ascend(func(i btree.Item) bool {
@@ -754,7 +757,7 @@ func (t *TableBlock) RowGroupIterator(
 			return true
 		}
 
-		g.PartBuffersForTx(watermark, func(buf *dynparquet.SerializedBuffer) bool {
+		g.PartBuffersForTx(tx, func(buf *dynparquet.SerializedBuffer) bool {
 			f := buf.ParquetFile()
 			for i := range f.RowGroups() {
 				rg := buf.DynamicRowGroup(i)
@@ -1007,7 +1010,7 @@ func (t *TableBlock) Serialize() ([]byte, error) {
 
 	// Read all row groups
 	rowGroups := []dynparquet.DynamicRowGroup{}
-	err := t.RowGroupIterator(ctx, nil, &AlwaysTrueFilter{}, true, func(rg dynparquet.DynamicRowGroup) bool {
+	err := t.RowGroupIterator(ctx, math.MaxUint64, nil, &AlwaysTrueFilter{}, func(rg dynparquet.DynamicRowGroup) bool {
 		rowGroups = append(rowGroups, rg)
 		return true
 	})

--- a/table_test.go
+++ b/table_test.go
@@ -1336,6 +1336,8 @@ func Test_Table_ArrowSchema(t *testing.T) {
 			},
 			nil, nil,
 		)
+		require.NoError(t, err)
+
 		require.Len(t, schema.Fields(), 4)
 		require.Equal(t,
 			arrow.Field{Name: "labels.label1", Type: &arrow.BinaryType{}, Nullable: true, Metadata: arrow.Metadata{}},

--- a/table_test.go
+++ b/table_test.go
@@ -1207,6 +1207,27 @@ func Test_Table_ArrowSchema(t *testing.T) {
 	_, err = table.InsertBuffer(ctx, buf)
 	require.NoError(t, err)
 
+	samples = dynparquet.Samples{{
+		ExampleType: "test",
+		Labels: []dynparquet.Label{
+			{Name: "label1", Value: "value1"},
+			{Name: "label2", Value: "value2"},
+			{Name: "label3", Value: "value3"},
+		},
+		Stacktrace: []uuid.UUID{
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3},
+		},
+		Timestamp: 1,
+		Value:     2,
+	}}
+
+	buf, err = samples.ToBuffer(table.Schema())
+	require.NoError(t, err)
+
+	_, err = table.InsertBuffer(ctx, buf)
+	require.NoError(t, err)
+
 	schema, err := table.ArrowSchema(
 		ctx,
 		memory.NewGoAllocator(),
@@ -1214,7 +1235,7 @@ func Test_Table_ArrowSchema(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.Len(t, schema.Fields(), 6)
+	require.Len(t, schema.Fields(), 7)
 	require.Equal(t,
 		arrow.Field{Name: "example_type", Type: &arrow.BinaryType{}, Nullable: false, Metadata: arrow.Metadata{}},
 		schema.Field(0),
@@ -1228,15 +1249,19 @@ func Test_Table_ArrowSchema(t *testing.T) {
 		schema.Field(2),
 	)
 	require.Equal(t,
-		arrow.Field{Name: "stacktrace", Type: &arrow.BinaryType{}, Nullable: false, Metadata: arrow.Metadata{}},
+		arrow.Field{Name: "labels.label3", Type: &arrow.BinaryType{}, Nullable: true, Metadata: arrow.Metadata{}},
 		schema.Field(3),
 	)
 	require.Equal(t,
-		arrow.Field{Name: "timestamp", Type: &arrow.Int64Type{}, Nullable: false, Metadata: arrow.Metadata{}},
+		arrow.Field{Name: "stacktrace", Type: &arrow.BinaryType{}, Nullable: false, Metadata: arrow.Metadata{}},
 		schema.Field(4),
 	)
 	require.Equal(t,
-		arrow.Field{Name: "value", Type: &arrow.Int64Type{}, Nullable: false, Metadata: arrow.Metadata{}},
+		arrow.Field{Name: "timestamp", Type: &arrow.Int64Type{}, Nullable: false, Metadata: arrow.Metadata{}},
 		schema.Field(5),
+	)
+	require.Equal(t,
+		arrow.Field{Name: "value", Type: &arrow.Int64Type{}, Nullable: false, Metadata: arrow.Metadata{}},
+		schema.Field(6),
 	)
 }


### PR DESCRIPTION
It's helpful to return the computed schema for a request. 
The `TableReader` now has an `ArrowSchema` method that under the hood uses the same `ParquetRowGroupToArrowRecord` function that's used to generate the Arrow Records that now additionally returns the schema belonging to those records. 